### PR TITLE
Add POST /users endpoint with username and password validation (#26)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
@@ -26,9 +26,6 @@ public class User implements Serializable {
 	@GeneratedValue
 	private Long id;
 
-	@Column(nullable = false)
-	private String name;
-
 	@Column(nullable = false, unique = true)
 	private String username;
 
@@ -38,20 +35,26 @@ public class User implements Serializable {
 	@Column(nullable = false)
 	private UserStatus status;
 
+	@Column(nullable = false)
+	private String password;
+
+
+	public String getPassword() { 
+		return password; 
+	}
+
+
+	public void setPassword(String password) { 
+		this.password = password; 
+	}
+
+
 	public Long getId() {
 		return id;
 	}
 
 	public void setId(Long id) {
 		this.id = id;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
 	}
 
 	public String getUsername() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
@@ -7,7 +7,5 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 
 @Repository("userRepository")
 public interface UserRepository extends JpaRepository<User, Long> {
-	User findByName(String name);
-
-	User findByUsername(String username);
+    User findByUsername(String username);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
@@ -2,23 +2,22 @@ package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
 public class UserPostDTO {
 
-	private String name;
+    private String username;
+    private String password;
 
-	private String username;
+    public String getUsername() { 
+			return username; 
+		}
 
-	public String getName() {
-		return name;
-	}
+    public void setUsername(String username) {
+			this.username = username; 
+		}
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public String getPassword() { 
+			return password; 
+		}
 
-	public String getUsername() {
-		return username;
-	}
-
-	public void setUsername(String username) {
-		this.username = username;
-	}
+    public void setPassword(String password) { 
+			this.password = password; 
+		}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -23,12 +23,11 @@ public interface DTOMapper {
 
 	DTOMapper INSTANCE = Mappers.getMapper(DTOMapper.class);
 
-	@Mapping(source = "name", target = "name")
 	@Mapping(source = "username", target = "username")
+	@Mapping(source = "password", target = "password")
 	User convertUserPostDTOtoEntity(UserPostDTO userPostDTO);
 
 	@Mapping(source = "id", target = "id")
-	@Mapping(source = "name", target = "name")
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "status", target = "status")
 	UserGetDTO convertEntityToUserGetDTO(User user);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -39,16 +39,14 @@ public class UserService {
 	}
 
 	public User createUser(User newUser) {
-		newUser.setToken(UUID.randomUUID().toString());
-		newUser.setStatus(UserStatus.OFFLINE);
-		checkIfUserExists(newUser);
-		// saves the given entity but data is only persisted in the database once
-		// flush() is called
-		newUser = userRepository.save(newUser);
-		userRepository.flush();
-
-		log.debug("Created Information for User: {}", newUser);
-		return newUser;
+    validateUserInput(newUser);
+    newUser.setToken(UUID.randomUUID().toString());
+    newUser.setStatus(UserStatus.OFFLINE);
+    checkIfUserExists(newUser);
+    newUser = userRepository.save(newUser);
+    userRepository.flush();
+    log.debug("Created Information for User: {}", newUser);
+    return newUser;
 	}
 
 	/**
@@ -62,17 +60,22 @@ public class UserService {
 	 * @see User
 	 */
 	private void checkIfUserExists(User userToBeCreated) {
-		User userByUsername = userRepository.findByUsername(userToBeCreated.getUsername());
-		User userByName = userRepository.findByName(userToBeCreated.getName());
+    User userByUsername = userRepository.findByUsername(userToBeCreated.getUsername());
+    if (userByUsername != null) {
+        throw new ResponseStatusException(HttpStatus.CONFLICT,
+            "Username already taken. Please choose a different one.");
+    }
+	}	
 
-		String baseErrorMessage = "The %s provided %s not unique. Therefore, the user could not be created!";
-		if (userByUsername != null && userByName != null) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-					String.format(baseErrorMessage, "username and the name", "are"));
-		} else if (userByUsername != null) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, String.format(baseErrorMessage, "username", "is"));
-		} else if (userByName != null) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, String.format(baseErrorMessage, "name", "is"));
-		}
+	private void validateUserInput(User user) {
+    if (user.getUsername() == null || user.getUsername().isBlank()) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username is required.");
+    }
+    if (user.getPassword() == null || user.getPassword().isBlank()) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Password is required.");
+    }
+    if (user.getPassword().length() < 6) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Password must be at least 6 characters.");
+    }
 	}
 }


### PR DESCRIPTION
## What was implemented
Added the `POST /users` endpoint to allow new users to register with a username and password.

## Changes
- Added `password` field to `User` entity and `UserPostDTO`
- Added manual validation in `UserService` (blank fields → 400, duplicate username → 409)
- Removed unused `name` field references from `UserRepository` and `UserService`
- Endpoint returns 201 with user object on success

Closes shiqing1412/sopra-fs26-group-17-server#26
Closes shiqing1412/sopra-fs26-group-17-client#24 