### PR TITLE
Hash password with BCrypt before persisting user (#28)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'   
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'at.favre.lib:bcrypt:0.10.2'
 }
 
 bootJar {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -43,6 +43,9 @@ public class UserService {
     newUser.setToken(UUID.randomUUID().toString());
     newUser.setStatus(UserStatus.OFFLINE);
     checkIfUserExists(newUser);
+		String hashedPassword = at.favre.lib.crypto.bcrypt.BCrypt.withDefaults()
+            .hashToString(12, newUser.getPassword().toCharArray());
+    newUser.setPassword(hashedPassword);
     newUser = userRepository.save(newUser);
     userRepository.flush();
     log.debug("Created Information for User: {}", newUser);


### PR DESCRIPTION
## What was implemented
Added BCrypt password hashing before persisting the user record to the database.

## Changes
- Added `at.favre.lib:bcrypt` dependency to `build.gradle`
- Password is hashed with BCrypt (cost factor 12) in `UserService.createUser()` before saving
- Password is never returned in the API response

Closes #28