### PR TITLE
Validate password and passwordConfirm match in POST /users (#62)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
@@ -47,6 +48,10 @@ public class UserController {
 	@ResponseStatus(HttpStatus.CREATED)
 	@ResponseBody
 	public UserGetDTO createUser(@RequestBody UserPostDTO userPostDTO) {
+		if (userPostDTO.getPasswordConfirm() == null || 
+        !userPostDTO.getPassword().equals(userPostDTO.getPasswordConfirm())) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Passwords do not match.");
+    }
 		// convert API user to internal representation
 		User userInput = DTOMapper.INSTANCE.convertUserPostDTOtoEntity(userPostDTO);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
@@ -32,7 +32,7 @@ public class User implements Serializable {
 	@Column(nullable = false)
 	private String password;
 
-	@Column(nullable = false)
+	@Column(nullable = true, unique = true)
 	private String token;
 
 	@Column(nullable = false)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
@@ -4,6 +4,7 @@ public class UserPostDTO {
 
     private String username;
     private String password;
+		private String passwordConfirm;
 
     public String getUsername() { 
 			return username; 
@@ -19,5 +20,13 @@ public class UserPostDTO {
 
     public void setPassword(String password) { 
 			this.password = password; 
+		}
+
+		public String getPasswordConfirm() { 
+			return passwordConfirm; 
+		}
+
+		public void setPasswordConfirm(String passwordConfirm) { 
+			this.passwordConfirm = passwordConfirm; 
 		}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -64,8 +64,10 @@ public class UserService {
 		if (user == null) {
 			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "The username is not correct!"); //401 Unauthorized
 		}
-		if (!user.getPassword().equals(password)) {
-			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "The password is incorrect!"); //401 Unauthorized
+		boolean passwordMatch = at.favre.lib.crypto.bcrypt.BCrypt.verifyer()
+        .verify(password.toCharArray(), user.getPassword()).verified;
+		if (!passwordMatch) {
+				throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "The password is incorrect!");
 		}
 		user.setStatus(UserStatus.ONLINE);
 		user.setToken(UUID.randomUUID().toString());


### PR DESCRIPTION
## What was implemented
Added password confirmation validation to the `POST /users` endpoint, so that the frontend can send a `passwordConfirm` field and the backend verifies both passwords match before creating the user.

## Changes
- Added `passwordConfirm` field to `UserPostDTO`
- Added check in `UserController.createUser()` that `password` and `passwordConfirm` match (→ 400 if not)

## Bug fixes
- Fixed password verification on login to use BCrypt's `verifyer()` instead of `.equals()` (plain text comparison was failing against hashed passwords)
- Fixed logout crash by setting `token` column to `nullable = true` in `User.java` (logout sets token to null, which was violating the not-null constraint)

Closes #62