### PR TITLE
Restrict access to authenticated trip members only (#98)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
@@ -1,0 +1,34 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
+import ch.uzh.ifi.hase.soprafs26.service.EventService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/trips")
+public class EventController {
+  private final EventService eventService;
+  private final UserService userService;
+
+  public EventController(EventService eventService, UserService userService) {
+    this.eventService = eventService;
+    this.userService = userService;
+  }
+
+  @GetMapping("/{tripId}/events")
+  @ResponseStatus(HttpStatus.OK)
+  @ResponseBody
+  public List<DayDTO> getEventsGroupedByDay(
+        @PathVariable Long tripId,
+        @RequestHeader("Authorization") String token) {
+
+    User requestingUser = userService.validateToken(token);
+    return eventService.getEventsGroupedByDay(tripId, requestingUser);
+  }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
@@ -45,4 +45,14 @@ public class TripController {
 		return tripService.joinTrip(joinToken, currentUser);
 	}
 
+	@GetMapping("/{tripId}")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public TripGetDTO getTripById(@PathVariable Long tripId, @RequestHeader("Authorization") String token) {
+		User currentUser = userService.validateToken(token);
+		Trip trip = tripService.getTripById(tripId);
+		tripService.checkMembership(trip, currentUser);
+		return DTOMapper.INSTANCE.convertEntityToTripGetDTO(trip);
+	}
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Event.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Event.java
@@ -1,0 +1,71 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "events")
+public class Event implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue
+    private Long eventId;
+
+    @Column(nullable = false)
+    private String eventTitle;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = true)
+    private LocalTime time;
+
+    @Column(nullable = true, length = 1000)
+    private String notes;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Embedded
+    private Location location;
+
+    @ManyToOne
+    @JoinColumn(name = "creator_id", nullable = false)
+    private User creator;
+
+    @ManyToOne
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip;
+
+    public Long getEventId() { return eventId; }
+    public void setEventId(Long eventId) { this.eventId = eventId; }
+
+    public String getEventTitle() { return eventTitle; }
+    public void setEventTitle(String eventTitle) { this.eventTitle = eventTitle; }
+
+    public LocalDate getDate() { return date; }
+    public void setDate(LocalDate date) { this.date = date; }
+
+    public LocalTime getTime() { return time; }
+    public void setTime(LocalTime time) { this.time = time; }
+
+    public String getNotes() { return notes; }
+    public void setNotes(String notes) { this.notes = notes; }
+
+    public Location getLocation() { return location; }
+    public void setLocation(Location location) { this.location = location; }
+
+    public User getCreator() { return creator; }
+    public void setCreator(User creator) { this.creator = creator; }
+
+    public Trip getTrip() { return trip; }
+    public void setTrip(Trip trip) { this.trip = trip; }
+
+    public LocalDateTime getCreatedAt() {return createdAt;}
+    public void setCreatedAt(LocalDateTime createdAt) {this.createdAt = createdAt;}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Location.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Location.java
@@ -1,0 +1,34 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+
+@Embeddable //no table of its own (columns live in "events" table)
+public class Location implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Column(nullable = false)
+    private String placeId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Double latitude;
+
+    @Column(nullable = false)
+    private Double longitude;
+
+    public String getPlaceId() { return placeId; }
+    public void setPlaceId(String placeId) { this.placeId = placeId; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public Double getLatitude() { return latitude; }
+    public void setLatitude(Double latitude) { this.latitude = latitude; }
+
+    public Double getLongitude() { return longitude; }
+    public void setLongitude(Double longitude) { this.longitude = longitude; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventRepository.java
@@ -1,0 +1,17 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Event;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository("eventRepository")
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+    List<Event> findByTrip_TripIdOrderByDateAscTimeAsc(Long tripId);
+
+    List<Event> findByTrip_TripIdAndCreatedAtAfter(Long tripId, LocalDateTime since);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/DayDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/DayDTO.java
@@ -1,0 +1,20 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class DayDTO {
+  private LocalDate date;
+  private List<EventGetDTO> events;
+
+  public DayDTO(LocalDate date, List<EventGetDTO> events) {
+      this.date = date;
+      this.events = events;
+  }
+
+  public LocalDate getDate() { return date; }
+  public void setDate(LocalDate date) { this.date = date; }
+
+  public List<EventGetDTO> getEvents() { return events; }
+  public void setEvents(List<EventGetDTO> events) { this.events = events; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventGetDTO.java
@@ -1,0 +1,43 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class EventGetDTO {
+  private Long eventId;
+  private String eventTitle;
+  private LocalDate date;
+  private LocalTime time;
+  private String notes;
+  private String placeName;
+  private Double lat;
+  private Double lng;
+  private String createdBy;
+
+  public Long getEventId() { return eventId; }
+  public void setEventId(Long eventId) { this.eventId = eventId; }
+
+  public String getEventTitle() { return eventTitle; }
+  public void setEventTitle(String eventTitle) { this.eventTitle = eventTitle; }
+
+  public LocalDate getDate() { return date; }
+  public void setDate(LocalDate date) { this.date = date; }
+
+  public LocalTime getTime() { return time; }
+  public void setTime(LocalTime time) { this.time = time; }
+
+  public String getNotes() { return notes; }
+  public void setNotes(String notes) { this.notes = notes; }
+
+  public String getPlaceName() { return placeName; }
+  public void setPlaceName(String placeName) { this.placeName = placeName; }
+
+  public Double getLat() { return lat; }
+  public void setLat(Double lat) { this.lat = lat; }
+
+  public Double getLng() { return lng; }
+  public void setLng(Double lng) { this.lng = lng; }
+
+  public String getCreatedBy() { return createdBy; }
+  public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPostDTO.java
@@ -1,0 +1,40 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class EventPostDTO {
+  private String eventTitle;
+  private LocalDate dayDate;
+  private LocalTime time;
+  private String notes;
+
+  private String placeId;
+  private String placeName;
+  private Double lat;
+  private Double lng;
+
+  public String getEventTitle() { return eventTitle; }
+  public void setEventTitle(String eventTitle) { this.eventTitle = eventTitle; }
+
+  public LocalDate getDayDate() { return dayDate; }
+  public void setDayDate(LocalDate dayDate) { this.dayDate = dayDate; }
+
+  public LocalTime getTime() { return time; }
+  public void setTime(LocalTime time) { this.time = time; }
+
+  public String getNotes() { return notes; }
+  public void setNotes(String notes) { this.notes = notes; }
+
+  public String getPlaceId() { return placeId; }
+  public void setPlaceId(String placeId) { this.placeId = placeId; }
+
+  public String getPlaceName() { return placeName; }
+  public void setPlaceName(String placeName) { this.placeName = placeName; }
+
+  public Double getLat() { return lat; }
+  public void setLat(Double lat) { this.lat = lat; }
+
+  public Double getLng() { return lng; }
+  public void setLng(Double lng) { this.lng = lng; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -9,6 +9,9 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.TripGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
+import ch.uzh.ifi.hase.soprafs26.entity.Event;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
+
 
 /**
  * DTOMapper
@@ -48,6 +51,15 @@ public interface DTOMapper {
 	@Mapping(source = "owner", target = "owner", qualifiedByName = "mapUserToUsername")
 	@Mapping(source = "shareCode", target = "shareCode")
 	TripGetDTO convertEntityToTripGetDTO(Trip trip);
+
+	@Mapping(source = "date",            target = "date")
+	@Mapping(source = "time",            target = "time")
+	@Mapping(source = "notes",           target = "notes")
+	@Mapping(source = "location.name",   target = "placeName")
+	@Mapping(source = "location.latitude",  target = "lat")
+	@Mapping(source = "location.longitude", target = "lng")
+	@Mapping(source = "creator",         target = "createdBy", qualifiedByName = "mapUserToUsername")
+	EventGetDTO convertEntityToEventGetDTO(Event event);
 
 	@Named("mapUserToUsername")
 	default String mapUserToUsername(User user) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -1,0 +1,60 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Event;
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.EventRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class EventService {
+
+    private final EventRepository eventRepository;
+    private final TripService tripService;
+
+    public EventService(EventRepository eventRepository, TripService tripService) {
+        this.eventRepository = eventRepository;
+        this.tripService = tripService;
+    }
+
+    public List<DayDTO> getEventsGroupedByDay(Long tripId, User requestingUser) {
+        Trip trip = tripService.getTripById(tripId);
+        tripService.checkMembership(trip, requestingUser);
+
+        List<Event> events = eventRepository
+            .findByTrip_TripIdOrderByDateAscTimeAsc(tripId);
+
+        Map<LocalDate, List<EventGetDTO>> byDate = events.stream()
+            .collect(Collectors.groupingBy(
+                Event::getDate,
+                Collectors.mapping(
+                    DTOMapper.INSTANCE::convertEntityToEventGetDTO,
+                    Collectors.toList()
+                )
+            ));
+
+        // One DayDTO per day in trip range, empty list if no events
+        List<DayDTO> days = new ArrayList<>();
+        LocalDate cursor = trip.getStartDate();
+        while (!cursor.isAfter(trip.getEndDate())) {
+            days.add(new DayDTO(cursor, byDate.getOrDefault(cursor, List.of())));
+            cursor = cursor.plusDays(1);
+        }
+
+        return days;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -102,6 +102,23 @@ public class TripService {
         return response;
     }
 
+    public void checkMembership(Trip trip, User user) {
+    boolean isMember = membershipRepository.existsByTripAndUser(trip, user);
+    boolean isOwner = trip.getOwner().getUserId().equals(user.getUserId());
+    if (!isMember && !isOwner) {
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+            "You are not a member of this trip.");
+        }
+    }
+
+    public Trip getTripById(Long tripId) {
+        return tripRepository.findById(tripId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                "Trip not found."));
+    }
+
+    
+
 
 }
 


### PR DESCRIPTION
## Changes

### Modified `TripService`
- **`getTripById`** — resolves a trip by id or throws 404
- **`checkMembership`** — checks if a user is a member or owner of a trip, throws 403 if not. Single source of truth for membership enforcement used by both `TripService` and `EventService`

### Modified `TripController`
- **`GET /trips/{tripId}`** — returns trip details, enforces membership check (403 if not a member, 404 if trip not found)

### Modified `EventService`
- Replaced inline membership check with `tripService.checkMembership` — removed direct dependency on `TripRepository` and `MembershipRepository`

Closes #98