### PR TITLE
implement POST /trips/{tripId}/events endpoint (#137, #139, #140)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
@@ -7,6 +7,8 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
 import ch.uzh.ifi.hase.soprafs26.service.EventService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 
 import java.util.List;
 
@@ -30,5 +32,17 @@ public class EventController {
 
     User requestingUser = userService.validateToken(token);
     return eventService.getEventsGroupedByDay(tripId, requestingUser);
+  }
+
+  @PostMapping("/{tripId}/events")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ResponseBody
+  public EventGetDTO createEvent(
+          @PathVariable Long tripId,
+          @RequestHeader("Authorization") String token,
+          @RequestBody EventPostDTO eventPostDTO) {
+
+      User requestingUser = userService.validateToken(token);
+      return eventService.createEvent(tripId, eventPostDTO, requestingUser);
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -12,6 +12,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
 import ch.uzh.ifi.hase.soprafs26.entity.Event;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 
 
 /**
@@ -69,6 +70,17 @@ public interface DTOMapper {
 	@Mapping(source = "location.longitude", target = "lng")
 	@Mapping(source = "creator",         target = "createdBy", qualifiedByName = "mapUserToUsername")
 	EventGetDTO convertEntityToEventGetDTO(Event event);
+
+	@Mapping(source = "eventTitle", target = "eventTitle")
+	@Mapping(source = "dayDate",    target = "date")
+	@Mapping(source = "time",       target = "time")
+	@Mapping(source = "notes",      target = "notes")
+	@Mapping(target = "location",   ignore = true)
+	@Mapping(target = "creator",    ignore = true)
+	@Mapping(target = "trip",       ignore = true)
+	@Mapping(target = "createdAt",  ignore = true)
+	@Mapping(target = "eventId",    ignore = true)
+	Event convertEventPostDTOtoEntity(EventPostDTO eventPostDTO);
 
 	@Named("mapUserToUsername")
 	default String mapUserToUsername(User user) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -14,7 +14,10 @@ import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.entity.Location;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 
+import java.time.LocalDateTime;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,5 +79,38 @@ public class EventService {
     }
 
     return days;
+  }
+
+  public EventGetDTO createEvent(Long tripId, EventPostDTO dto, User creator) {
+    Trip trip = tripRepository.findById(tripId)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+        "Trip not found."));
+
+    boolean isMember = membershipRepository.existsByTripIdAndUserId(tripId, creator.getUserId());
+    if (!isMember) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+        "You are not a member of this trip.");
+    }
+
+    if (dto.getDayDate().isBefore(trip.getStartDate()) || dto.getDayDate().isAfter(trip.getEndDate())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+        "Event date is outside the trip's date range.");
+    }
+
+    Event event = DTOMapper.INSTANCE.convertEventPostDTOtoEntity(dto);
+
+    Location location = new Location();
+    location.setPlaceId(dto.getPlaceId());
+    location.setName(dto.getPlaceName());
+    location.setLatitude(dto.getLat());
+    location.setLongitude(dto.getLng());
+
+    event.setLocation(location);
+    event.setCreator(creator);
+    event.setTrip(trip);
+    event.setCreatedAt(LocalDateTime.now());
+
+    Event saved = eventRepository.save(event);
+    return DTOMapper.INSTANCE.convertEntityToEventGetDTO(saved);
   }
 }


### PR DESCRIPTION


Adds the ability for trip members to create events with Google Places location data.

## Changes
- `DTOMapper`: added `convertEventPostDTOtoEntity` 
- `EventService`: added `createEvent` - resolves trip (404), checks membership (403), validates date within trip range (400), builds and persists `Event` with embedded `Location`, sets creator from token and timestamps `createdAt`
- `EventController`: added `POST /{tripId}/events` endpoint returning 201 with `EventGetDTO`

Closes #137
Closes #139
Closes #140

---