### PR TITLE
Endpoint edit an event

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
@@ -5,6 +5,8 @@ import org.springframework.web.bind.annotation.*;
 
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPutDTO;
 import ch.uzh.ifi.hase.soprafs26.service.EventService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 
@@ -30,5 +32,17 @@ public class EventController {
 
     User requestingUser = userService.validateToken(token);
     return eventService.getEventsGroupedByDay(tripId, requestingUser);
+  }
+
+  @PutMapping("/{tripId}/events/{eventId}")
+  @ResponseStatus(HttpStatus.OK)
+  @ResponseBody
+  public EventGetDTO updateEvent(
+        @PathVariable Long tripId,
+        @PathVariable Long eventId,
+        @RequestHeader("Authorization") String token,
+        @RequestBody EventPutDTO eventPutDTO) {
+          User requestingUser = userService.validateToken(token);
+          return eventService.updateEvent(eventId, eventPutDTO);
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
@@ -9,8 +9,6 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPutDTO;
 import ch.uzh.ifi.hase.soprafs26.service.EventService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 
 import java.util.List;
 
@@ -36,7 +34,6 @@ public class EventController {
     return eventService.getEventsGroupedByDay(tripId, requestingUser);
   }
 
-<<<<<<< HEAD
   @PutMapping("/{tripId}/events/{eventId}")
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
@@ -46,18 +43,6 @@ public class EventController {
         @RequestHeader("Authorization") String token,
         @RequestBody EventPutDTO eventPutDTO) {
           User requestingUser = userService.validateToken(token);
-          return eventService.updateEvent(eventId, eventPutDTO);
-=======
-  @PostMapping("/{tripId}/events")
-  @ResponseStatus(HttpStatus.CREATED)
-  @ResponseBody
-  public EventGetDTO createEvent(
-          @PathVariable Long tripId,
-          @RequestHeader("Authorization") String token,
-          @RequestBody EventPostDTO eventPostDTO) {
-
-      User requestingUser = userService.validateToken(token);
-      return eventService.createEvent(tripId, eventPostDTO, requestingUser);
->>>>>>> main
+          return eventService.updateEvent(tripId, eventId, eventPutDTO, requestingUser);
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
@@ -7,6 +7,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPutDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 import ch.uzh.ifi.hase.soprafs26.service.EventService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 
@@ -32,6 +33,17 @@ public class EventController {
 
     User requestingUser = userService.validateToken(token);
     return eventService.getEventsGroupedByDay(tripId, requestingUser);
+  }
+
+  @PostMapping("/{tripId}/events")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ResponseBody
+  public EventGetDTO createEvent(
+        @PathVariable Long tripId,
+        @RequestHeader("Authorization") String token,
+        @RequestBody EventPostDTO eventPostDTO) {
+          User requestingUser = userService.validateToken(token);
+          return eventService.createEvent(tripId, eventPostDTO, requestingUser);
   }
 
   @PutMapping("/{tripId}/events/{eventId}")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Location.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Location.java
@@ -15,10 +15,10 @@ public class Location implements Serializable {
     private String name;
 
     @Column(nullable = false)
-    private Double latitude;
+    private Double lat;
 
     @Column(nullable = false)
-    private Double longitude;
+    private Double lng;
 
     public String getPlaceId() { return placeId; }
     public void setPlaceId(String placeId) { this.placeId = placeId; }
@@ -26,9 +26,9 @@ public class Location implements Serializable {
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
 
-    public Double getLatitude() { return latitude; }
-    public void setLatitude(Double latitude) { this.latitude = latitude; }
+    public Double getLat() { return lat; }
+    public void setLat(Double lat) { this.lat = lat; }
 
-    public Double getLongitude() { return longitude; }
-    public void setLongitude(Double longitude) { this.longitude = longitude; }
+    public Double getLng() { return lng; }
+    public void setLng(Double lng) { this.lng = lng; }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Trip.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Trip.java
@@ -3,7 +3,6 @@ package ch.uzh.ifi.hase.soprafs26.entity;
 import jakarta.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDate;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventRepository.java
@@ -13,4 +13,7 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findByTrip_TripIdOrderByDateAscTimeAsc(Long tripId);
 
     List<Event> findByTrip_TripIdAndCreatedAtAfter(Long tripId, LocalDateTime since);
+
+    List<Event> findByTrip_TripIdAndEventId(Long tripId, Long eventId);
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPostDTO.java
@@ -5,10 +5,9 @@ import java.time.LocalTime;
 
 public class EventPostDTO {
   private String eventTitle;
-  private LocalDate dayDate;
+  private LocalDate date;
   private LocalTime time;
   private String notes;
-
   private String placeId;
   private String placeName;
   private Double lat;
@@ -17,8 +16,8 @@ public class EventPostDTO {
   public String getEventTitle() { return eventTitle; }
   public void setEventTitle(String eventTitle) { this.eventTitle = eventTitle; }
 
-  public LocalDate getDayDate() { return dayDate; }
-  public void setDayDate(LocalDate dayDate) { this.dayDate = dayDate; }
+  public LocalDate getDate() { return date; }
+  public void setDate(LocalDate date) { this.date = date; }
 
   public LocalTime getTime() { return time; }
   public void setTime(LocalTime time) { this.time = time; }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPutDTO.java
@@ -10,6 +10,7 @@ public class EventPutDTO {
     private LocalDate date;
     private LocalTime time;
     private String notes;
+    private String placeId;
     private String placeName;
     private Double lat;
     private Double lng;
@@ -28,6 +29,9 @@ public class EventPutDTO {
 
     public String getNotes() { return notes; }
     public void setNotes(String notes) { this.notes = notes; }
+
+    public String getPlaceId() { return placeId; }
+    public void setPlaceId(String placeId) { this.placeId = placeId; }  
 
     public String getPlaceName() { return placeName; }
     public void setPlaceName(String placeName) { this.placeName = placeName; }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPutDTO.java
@@ -1,0 +1,38 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class EventPutDTO {
+    
+    private String eventTitle;
+    private LocalDate date;
+    private LocalTime time;
+    private String notes;
+    private String placeName;
+    private Double lat;
+    private Double lng;
+    
+    public String getEventTitle() { return eventTitle; }
+    public void setEventTitle(String eventTitle) { this.eventTitle = eventTitle; }
+
+    public LocalDate getDate() { return date; }
+    public void setDate(LocalDate date) { this.date = date; }
+
+    public LocalTime getTime() { return time; }
+    public void setTime(LocalTime time) { this.time = time; }
+
+    public String getNotes() { return notes; }
+    public void setNotes(String notes) { this.notes = notes; }
+
+    public String getPlaceName() { return placeName; }
+    public void setPlaceName(String placeName) { this.placeName = placeName; }
+
+    public Double getLat() { return lat; }
+    public void setLat(Double lat) { this.lat = lat; }
+
+    public Double getLng() { return lng; }
+    public void setLng(Double lng) { this.lng = lng; }
+
+
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -37,13 +37,14 @@ public interface DTOMapper {
 
 	@Mapping(source = "userId", target = "userId")
 	@Mapping(source = "username", target = "username")
-	@Mapping(source = "token", target = "token")
 	@Mapping(source = "status", target = "status")
 	UserGetDTO convertEntityToUserGetDTO(User user);
 
 	@Mapping(source = "tripTitle", target = "tripTitle")
 	@Mapping(source = "startDate", target = "startDate")	
 	@Mapping(source = "endDate", target = "endDate")
+	@Mapping(target = "events", ignore = true)
+	@Mapping(target = "memberships", ignore = true)
 	Trip convertTripPostDTOtoEntity(TripPostDTO tripPostDTO);
 	
 	@Mapping(source = "tripId", target = "tripId")
@@ -60,19 +61,22 @@ public interface DTOMapper {
 	@Mapping(source = "endDate", target = "endDate")
 	@Mapping(source = "owner", target = "owner", qualifiedByName = "mapUserToUsername")
 	@Mapping(source = "shareCode", target = "shareCode")
+	@Mapping(source = "memberships", target = "members")
 	TripDetailDTO convertEntityToTripDetailDTO(Trip trip);
 
+	@Mapping(source = "eventId", target = "eventId")
+	@Mapping(source = "eventTitle", target = "eventTitle")
 	@Mapping(source = "date",            target = "date")
 	@Mapping(source = "time",            target = "time")
 	@Mapping(source = "notes",           target = "notes")
 	@Mapping(source = "location.name",   target = "placeName")
-	@Mapping(source = "location.latitude",  target = "lat")
-	@Mapping(source = "location.longitude", target = "lng")
-	@Mapping(source = "creator",         target = "createdBy", qualifiedByName = "mapUserToUsername")
+	@Mapping(source = "location.lat",  target = "lat")
+	@Mapping(source = "location.lng", target = "lng")
+	@Mapping(source = "creator",      target = "createdBy", qualifiedByName = "mapUserToUsername")
 	EventGetDTO convertEntityToEventGetDTO(Event event);
 
 	@Mapping(source = "eventTitle", target = "eventTitle")
-	@Mapping(source = "dayDate",    target = "date")
+	@Mapping(source = "date",    target = "date")
 	@Mapping(source = "time",       target = "time")
 	@Mapping(source = "notes",      target = "notes")
 	@Mapping(target = "location",   ignore = true)
@@ -86,6 +90,4 @@ public interface DTOMapper {
 	default String mapUserToUsername(User user) {
 		return user != null ? user.getUsername() : null;
 	}
-
-
 } 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -44,9 +44,9 @@ public class EventService {
   public List<DayDTO> getEventsGroupedByDay(Long tripId, User requestingUser) {
   
     Trip trip = findTripOrThrow(tripId); //404 if not found
-    /**Trip trip = tripRepository.findById(tripId)
+    /*Trip trip = tripRepository.findById(tripId)
       .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
-        "Trip not found."));**/
+        "Trip not found."));*/
         
     // Membership check    
     boolean isMember = membershipRepository
@@ -88,7 +88,7 @@ public class EventService {
   public EventGetDTO createEvent(Long tripId, EventPostDTO dto, User creator) {
     
     validateEventPostDTO(dto, null);
-    /**
+    /*
     if (dto.getEventTitle() == null || dto.getEventTitle().isBlank()) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "eventTitle is required.");
     }
@@ -107,24 +107,24 @@ public class EventService {
     if (dto.getLng() == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
     }
-    **/
-    /**
+    */
+    /*
     if (dto.getDate().isBefore(trip.getStartDate()) || dto.getDate().isAfter(trip.getEndDate())) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
         "Event date is outside the trip's date range.");
-    }**/
+    }*/
 
     Trip trip = findTripOrThrow(tripId);
-    /**Trip trip = tripRepository.findById(tripId)
+    /*Trip trip = tripRepository.findById(tripId)
       .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
-        "Trip not found."));**/
+        "Trip not found."));*/
     
     validateTripMember(tripId, creator);
-    /**boolean isMember = membershipRepository.existsByTripIdAndUserId(tripId, creator.getUserId());
+    /*oolean isMember = membershipRepository.existsByTripIdAndUserId(tripId, creator.getUserId());
     if (!isMember) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN,
         "You are not a member of this trip.");
-    }**/
+    }*/
 
     Event event = DTOMapper.INSTANCE.convertEventPostDTOtoEntity(dto);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -13,9 +13,10 @@ import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPutDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs26.entity.Location;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 
 import java.time.LocalDateTime;
 import java.time.LocalDate;
@@ -41,12 +42,13 @@ public class EventService {
   }
 
   public List<DayDTO> getEventsGroupedByDay(Long tripId, User requestingUser) {
-    //Resolve trip or 404
-    Trip trip = tripRepository.findById(tripId)
+  
+    Trip trip = findTripOrThrow(tripId); //404 if not found
+    /**Trip trip = tripRepository.findById(tripId)
       .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
-        "Trip not found."));
-
-    //Membership check
+        "Trip not found."));**/
+        
+    // Membership check    
     boolean isMember = membershipRepository
       .existsByTripIdAndUserId(tripId, requestingUser.getUserId());
     boolean isOwner = trip.getOwner().getUserId().equals(requestingUser.getUserId());
@@ -81,12 +83,17 @@ public class EventService {
     return days;
   }
 
+
+
   public EventGetDTO createEvent(Long tripId, EventPostDTO dto, User creator) {
+    
+    validateEventPostDTO(dto, null);
+    /**
     if (dto.getEventTitle() == null || dto.getEventTitle().isBlank()) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "eventTitle is required.");
     }
-    if (dto.getDayDate() == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "day_date is required.");
+    if (dto.getDate() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "date is required.");
     }
     if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_id is required.");
@@ -100,29 +107,32 @@ public class EventService {
     if (dto.getLng() == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
     }
-    
-    Trip trip = tripRepository.findById(tripId)
-      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
-        "Trip not found."));
+    **/
+    /**
+    if (dto.getDate().isBefore(trip.getStartDate()) || dto.getDate().isAfter(trip.getEndDate())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+        "Event date is outside the trip's date range.");
+    }**/
 
-    boolean isMember = membershipRepository.existsByTripIdAndUserId(tripId, creator.getUserId());
+    Trip trip = findTripOrThrow(tripId);
+    /**Trip trip = tripRepository.findById(tripId)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+        "Trip not found."));**/
+    
+    validateTripMember(tripId, creator);
+    /**boolean isMember = membershipRepository.existsByTripIdAndUserId(tripId, creator.getUserId());
     if (!isMember) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN,
         "You are not a member of this trip.");
-    }
-
-    if (dto.getDayDate().isBefore(trip.getStartDate()) || dto.getDayDate().isAfter(trip.getEndDate())) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-        "Event date is outside the trip's date range.");
-    }
+    }**/
 
     Event event = DTOMapper.INSTANCE.convertEventPostDTOtoEntity(dto);
 
     Location location = new Location();
     location.setPlaceId(dto.getPlaceId());
     location.setName(dto.getPlaceName());
-    location.setLatitude(dto.getLat());
-    location.setLongitude(dto.getLng());
+    location.setLat(dto.getLat());
+    location.setLng(dto.getLng());
 
     event.setLocation(location);
     event.setCreator(creator);
@@ -132,4 +142,113 @@ public class EventService {
     Event saved = eventRepository.save(event);
     return DTOMapper.INSTANCE.convertEntityToEventGetDTO(saved);
   }
+
+
+  //update event method
+  public EventGetDTO updateEvent(Long tripId, Long eventId, EventPutDTO dto, User requestingUser) {
+    Trip trip = findTripOrThrow(tripId); //404 if not found
+    Event event = findEventOrThrow(eventId);//404 if not found
+
+    validateEventBelongsToTrip(event, tripId);//404 if event not in this trip
+    validateTripMember(tripId, requestingUser);//403 if not member of this trip
+    validateEventPutDTO(dto, trip);//400 if any required field missing or event date outside trip range
+
+    event.setEventTitle(dto.getEventTitle());
+    event.setDate(dto.getDate()); 
+    event.setTime(dto.getTime());
+    event.setNotes(dto.getNotes());
+
+    if(event.getLocation() == null) {
+      event.setLocation(new Location());
+    }
+    event.getLocation().setPlaceId(dto.getPlaceId());
+    event.getLocation().setName(dto.getPlaceName());
+    event.getLocation().setLat(dto.getLat());
+    event.getLocation().setLng(dto.getLng());
+
+    Event updatedEvent = eventRepository.save(event);
+    return DTOMapper.INSTANCE.convertEntityToEventGetDTO(updatedEvent);
+}
+
+
+//validation methods
+
+  private Trip findTripOrThrow(Long tripId) {
+    return tripRepository.findById(tripId)
+    .orElseThrow(() -> new ResponseStatusException(
+      HttpStatus.NOT_FOUND, "Trip not found.")); //404
+    }
+
+  private Event findEventOrThrow(Long eventId) {
+    return eventRepository.findById(eventId)
+    .orElseThrow(() -> new ResponseStatusException(
+      HttpStatus.NOT_FOUND, "Event not found.")); //404
+    }
+
+  private void validateTripMember(Long tripId, User user) {
+    boolean isMember = membershipRepository.existsByTripIdAndUserId(tripId, user.getUserId());
+    if (!isMember) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+        "You are not a member of this trip.");//403
+      }
+    }
+
+  private void validateEventBelongsToTrip(Event event, Long tripId) {
+    if (!event.getTrip().getTripId().equals(tripId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+        "Event not found in this trip."); //404
+      }
+    }
+
+  private void validateEventDateWithinTrip(LocalDate date, Trip trip) {
+    if (date.isBefore(trip.getStartDate()) || date.isAfter(trip.getEndDate())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+        "Event date is outside the trip's date range.");
+      }
+    }
+
+private void validateEventPostDTO(EventPostDTO dto, Trip trip) {
+  if (dto.getEventTitle() == null || dto.getEventTitle().isBlank()) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "eventTitle is required.");
+  }
+  if (dto.getDate() == null) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "date is required.");
+  }
+  if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_id is required.");
+  }
+  if (dto.getPlaceName() == null || dto.getPlaceName().isBlank()) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_name is required.");
+  }
+  if (dto.getLat() == null) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lat is required.");
+  }
+  if (dto.getLng() == null) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
+  }
+  validateEventDateWithinTrip(dto.getDate(), trip);
+}
+
+private void validateEventPutDTO(EventPutDTO dto, Trip trip) {
+  if (dto.getEventTitle() == null || dto.getEventTitle().isBlank()) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "eventTitle is required.");
+  }
+  if (dto.getDate() == null) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "date is required.");
+  }
+  if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_id is required.");
+  }
+  if (dto.getPlaceName() == null || dto.getPlaceName().isBlank()) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_name is required.");
+  }
+  if (dto.getLat() == null) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lat is required.");
+  }
+  if (dto.getLng() == null) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
+  }
+  validateEventDateWithinTrip(dto.getDate(), trip);
+}
+
 }


### PR DESCRIPTION
##Implemented

- Endpoint edit a event: PUT /trips/{tripId}/events/:eventId 
- `eventService` 
  - Validate authentication 
    - if the event exists (no: 404)
    - if the event is in the trip (no: 404)
    - if the editor is a member of the trip (no: 403)
  - Validate inputs
    -  eventTitle, placeId, placeName, date, lat, and lng are required
    -  time, notes are optional
    -  Fields missing or invalid, show 400 error
  - Persist update inputs

- Align some inconsistencies and small changes
  - latitude, longitude will be `lat`, `lng` instead
  - dayDate will be just `date`
  - remove token from Mapper
  - add memberships into Mapper
  

**Note**
Some validation codes are the same. They are organized into validation methods.
I applied them to the "createEvent" method with the original code commented out. 




Close #117  #118  #119 #120 #121
