### PR TITLE
Efficient GET /trips/{tripId}/events for 5s polling via ETag (#176)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
@@ -2,6 +2,8 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.WebRequest;
 
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
@@ -25,14 +27,20 @@ public class EventController {
   }
 
   @GetMapping("/{tripId}/events")
-  @ResponseStatus(HttpStatus.OK)
-  @ResponseBody
-  public List<DayDTO> getEventsGroupedByDay(
-        @PathVariable Long tripId,
-        @RequestHeader("Authorization") String token) {
+  public ResponseEntity<List<DayDTO>> getEventsGroupedByDay(
+      @PathVariable Long tripId,
+      @RequestHeader("Authorization") String token,
+      WebRequest webRequest) {
 
     User requestingUser = userService.validateToken(token);
-    return eventService.getEventsGroupedByDay(tripId, requestingUser);
+    List<DayDTO> days = eventService.getEventsGroupedByDay(tripId, requestingUser);
+
+    String eTag = String.valueOf(days.hashCode());
+    if (webRequest.checkNotModified(eTag)) {
+      return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
+    }
+
+    return ResponseEntity.ok(days);
   }
 
   @PostMapping("/{tripId}/events")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import ch.uzh.ifi.hase.soprafs26.entity.Event;
-import java.time.LocalDateTime;
+// import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository("eventRepository")
@@ -12,8 +12,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     List<Event> findByTrip_TripIdOrderByDateAscTimeAsc(Long tripId);
 
-    List<Event> findByTrip_TripIdAndCreatedAtAfter(Long tripId, LocalDateTime since);
+    // List<Event> findByTrip_TripIdAndCreatedAtAfter(Long tripId, LocalDateTime since);
 
-    List<Event> findByTrip_TripIdAndEventId(Long tripId, Long eventId);
+    // List<Event> findByTrip_TripIdAndEventId(Long tripId, Long eventId);
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/DayDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/DayDTO.java
@@ -2,14 +2,15 @@ package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 public class DayDTO {
   private LocalDate date;
   private List<EventGetDTO> events;
 
   public DayDTO(LocalDate date, List<EventGetDTO> events) {
-      this.date = date;
-      this.events = events;
+    this.date = date;
+    this.events = events;
   }
 
   public LocalDate getDate() { return date; }
@@ -17,4 +18,18 @@ public class DayDTO {
 
   public List<EventGetDTO> getEvents() { return events; }
   public void setEvents(List<EventGetDTO> events) { this.events = events; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof DayDTO)) return false;
+    DayDTO that = (DayDTO) o;
+    return Objects.equals(date, that.date)
+      && Objects.equals(events, that.events);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(date, events);
+  }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventGetDTO.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Objects;
 
 public class EventGetDTO {
   private Long eventId;
@@ -44,4 +45,27 @@ public class EventGetDTO {
 
   public String getCreatedBy() { return createdBy; }
   public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof EventGetDTO)) return false;
+    EventGetDTO that = (EventGetDTO) o;
+    return Objects.equals(eventId, that.eventId)
+      && Objects.equals(eventTitle, that.eventTitle)
+      && Objects.equals(date, that.date)
+      && Objects.equals(time, that.time)
+      && Objects.equals(notes, that.notes)
+      && Objects.equals(placeId, that.placeId)
+      && Objects.equals(placeName, that.placeName)
+      && Objects.equals(lat, that.lat)
+      && Objects.equals(lng, that.lng)
+      && Objects.equals(createdBy, that.createdBy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(eventId, eventTitle, date, time, notes,
+                        placeId, placeName, lat, lng, createdBy);
+  }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -49,14 +49,16 @@ public class EventService {
         "Trip not found."));*/
         
     // Membership check    
-    boolean isMember = membershipRepository
-      .existsByTripIdAndUserId(tripId, requestingUser.getUserId());
-    boolean isOwner = trip.getOwner().getUserId().equals(requestingUser.getUserId());
+    // boolean isMember = membershipRepository
+    //   .existsByTripIdAndUserId(tripId, requestingUser.getUserId());
+    // boolean isOwner = trip.getOwner().getUserId().equals(requestingUser.getUserId());
 
-    if (!isMember && !isOwner) {
-      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-        "You are not a member of this trip.");
-    }
+    // if (!isMember && !isOwner) {
+    //   throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+    //     "You are not a member of this trip.");
+    // }
+
+    validateTripMember(tripId, requestingUser);
 
     //Fetch all events for this trip, already sorted by date asc, time asc
     List<Event> events = eventRepository


### PR DESCRIPTION
Optimises `GET /trips/{tripId}/events` to be safe for 5-second polling by adding HTTP ETag-based conditional responses and removing redundant logic.

## Changes

### EventController.java
- Changed `getEventsGroupedByDay` to return `ResponseEntity<List<DayDTO>>` and accept `WebRequest`
- Added ETag support via `webRequest.checkNotModified(eTag)` - returns `304 Not Modified` with no body when events haven't changed since the last poll

### EventService.java
- Removed redundant owner check in `getEventsGroupedByDay`, owners already have a `Membership` row, so `validateTripMember` covers them; the old branch also triggered an unnecessary lazy-load of the `owner` User entity on every request

### EventRepository.java
- Commented out unused methods `findByTrip_TripIdAndCreatedAtAfter` and `findByTrip_TripIdAndEventId` 

### DayDTO.java / EventGetDTO.java
- Added `equals` and `hashCode` to both DTOs so the ETag hash is stable and content-derived. Without these, the hash would change on every request regardless of data

## How it works
On the first poll the server returns `200` with an `ETag` header. On every subsequent poll where nothing has changed, the client sends `If-None-Match: <etag>` and the server responds with `304 Not Modified` and an empty body: no serialisation cost, near-zero bandwidth.

Closes #176