### PR TITLE
Feature/181 add end time to event

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/ParticipationStatus.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/ParticipationStatus.java
@@ -1,0 +1,7 @@
+package ch.uzh.ifi.hase.soprafs26.constant;
+
+public enum ParticipationStatus {
+  JOINED,
+  DISMISSED,
+  OPTED_OUT
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Event.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Event.java
@@ -31,6 +31,9 @@ public class Event implements Serializable {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(nullable = true)
+    private LocalTime endTime;
+
     @Embedded
     private Location location;
 
@@ -68,4 +71,7 @@ public class Event implements Serializable {
 
     public LocalDateTime getCreatedAt() {return createdAt;}
     public void setCreatedAt(LocalDateTime createdAt) {this.createdAt = createdAt;}
+
+    public LocalTime getEndTime() { return endTime; }
+    public void setEndTime(LocalTime endTime) { this.endTime = endTime; }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Event.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Event.java
@@ -22,7 +22,7 @@ public class Event implements Serializable {
     @Column(nullable = false)
     private LocalDate date;
 
-    @Column(nullable = true)
+    @Column(nullable = false)
     private LocalTime time;
 
     @Column(nullable = true, length = 1000)
@@ -31,7 +31,7 @@ public class Event implements Serializable {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(nullable = true)
+    @Column(nullable = false)
     private LocalTime endTime;
 
     @Embedded

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/EventMember.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/EventMember.java
@@ -1,0 +1,43 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+
+import ch.uzh.ifi.hase.soprafs26.constant.ParticipationStatus;
+
+@Entity
+@Table(name = "event_members",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"event_id", "user_id"}))
+       
+public class EventMember implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue
+  private Long eventMemberId;
+
+  @ManyToOne
+  @JoinColumn(name = "event_id", nullable = false)
+  private Event event;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ParticipationStatus participationStatus;
+
+  public Long getEventMemberId() { return eventMemberId; }
+  public void setEventMemberId(Long eventMemberId) { this.eventMemberId = eventMemberId; }
+
+  public Event getEvent() { return event; }
+  public void setEvent(Event event) { this.event = event; }
+
+  public User getUser() { return user; }
+  public void setUser(User user) { this.user = user; }
+
+  public ParticipationStatus getParticipationStatus() { return participationStatus; }
+  public void setParticipationStatus(ParticipationStatus participationStatus) { this.participationStatus = participationStatus; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventMemberRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventMemberRepository.java
@@ -1,0 +1,32 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import ch.uzh.ifi.hase.soprafs26.constant.ParticipationStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.Event;
+import ch.uzh.ifi.hase.soprafs26.entity.EventMember;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface EventMemberRepository extends JpaRepository<EventMember, Long> {
+
+  List<EventMember> findByEvent(Event event);
+
+  Optional<EventMember> findByEventAndUser(Event event, User user);
+
+  @Query("SELECT em FROM EventMember em WHERE em.user = :user AND em.event.trip.tripId = :tripId")
+  List<EventMember> findByUserAndTripId(@Param("user") User user, @Param("tripId") Long tripId);
+
+  @Modifying
+  @Query("UPDATE EventMember em SET em.participationStatus = :status WHERE em.event = :event AND em.user = :user")
+  void updateStatusByEventAndUser(@Param("event") Event event,
+                                  @Param("user") User user,
+                                  @Param("status") ParticipationStatus status);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventGetDTO.java
@@ -15,6 +15,7 @@ public class EventGetDTO {
   private Double lat;
   private Double lng;
   private String createdBy;
+  private LocalTime endTime;
 
   public Long getEventId() { return eventId; }
   public void setEventId(Long eventId) { this.eventId = eventId; }
@@ -46,6 +47,9 @@ public class EventGetDTO {
   public String getCreatedBy() { return createdBy; }
   public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
 
+  public LocalTime getEndTime() { return endTime; }
+  public void setEndTime(LocalTime endTime) { this.endTime = endTime; }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -60,12 +64,13 @@ public class EventGetDTO {
       && Objects.equals(placeName, that.placeName)
       && Objects.equals(lat, that.lat)
       && Objects.equals(lng, that.lng)
-      && Objects.equals(createdBy, that.createdBy);
+      && Objects.equals(createdBy, that.createdBy)
+      && Objects.equals(endTime, that.endTime);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(eventId, eventTitle, date, time, notes,
-                        placeId, placeName, lat, lng, createdBy);
+    return Objects.hash(eventId, eventTitle, date, time, endTime, notes,
+      placeId, placeName, lat, lng, createdBy);
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPostDTO.java
@@ -12,6 +12,7 @@ public class EventPostDTO {
   private String placeName;
   private Double lat;
   private Double lng;
+  private LocalTime endTime;
 
   public String getEventTitle() { return eventTitle; }
   public void setEventTitle(String eventTitle) { this.eventTitle = eventTitle; }
@@ -36,4 +37,7 @@ public class EventPostDTO {
 
   public Double getLng() { return lng; }
   public void setLng(Double lng) { this.lng = lng; }
+
+  public LocalTime getEndTime() { return endTime; }
+  public void setEndTime(LocalTime endTime) { this.endTime = endTime; }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventPutDTO.java
@@ -14,6 +14,7 @@ public class EventPutDTO {
     private String placeName;
     private Double lat;
     private Double lng;
+    private LocalTime endTime;
     
     public Long getEventId() { return eventId; }
     public void setEventId(Long eventId) { this.eventId = eventId; }
@@ -42,5 +43,6 @@ public class EventPutDTO {
     public Double getLng() { return lng; }
     public void setLng(Double lng) { this.lng = lng; }
 
-
+    public LocalTime getEndTime() { return endTime; }
+    public void setEndTime(LocalTime endTime) { this.endTime = endTime; }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -14,6 +14,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
 import ch.uzh.ifi.hase.soprafs26.entity.Event;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPutDTO;
 
 
 /**
@@ -81,6 +82,7 @@ public interface DTOMapper {
 	@Mapping(source = "location.lat",  target = "lat")
 	@Mapping(source = "location.lng", target = "lng")
 	@Mapping(source = "creator",      target = "createdBy", qualifiedByName = "mapUserToUsername")
+	@Mapping(source = "endTime", target = "endTime")
 	EventGetDTO convertEntityToEventGetDTO(Event event);
 
 	@Mapping(source = "eventTitle", target = "eventTitle")
@@ -92,7 +94,20 @@ public interface DTOMapper {
 	@Mapping(target = "trip",       ignore = true)
 	@Mapping(target = "createdAt",  ignore = true)
 	@Mapping(target = "eventId",    ignore = true)
+	@Mapping(source = "endTime", target = "endTime")
 	Event convertEventPostDTOtoEntity(EventPostDTO eventPostDTO);
+
+	@Mapping(source = "eventTitle", target = "eventTitle")
+	@Mapping(source = "date",       target = "date")
+	@Mapping(source = "time",       target = "time")
+	@Mapping(source = "endTime",    target = "endTime")
+	@Mapping(source = "notes",      target = "notes")
+	@Mapping(target = "location",   ignore = true)
+	@Mapping(target = "creator",    ignore = true)
+	@Mapping(target = "trip",       ignore = true)
+	@Mapping(target = "createdAt",  ignore = true)
+	@Mapping(target = "eventId",    ignore = true)
+	Event convertEventPutDTOtoEntity(EventPutDTO eventPutDTO);
 
 	@Named("mapUserToUsername")
 	default String mapUserToUsername(User user) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -244,6 +244,12 @@ private void validateEventPostDTO(EventPostDTO dto, Trip trip) {
   if (dto.getLng() == null) {
     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
   }
+  if (dto.getTime() == null) {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "time is required.");
+  }
+  if (dto.getEndTime() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "endTime is required.");
+  }
   if (trip != null) {
     validateEventDateWithinTrip(dto.getDate(), trip);
   }
@@ -269,6 +275,10 @@ private void validateEventPutDTO(EventPutDTO dto, Trip trip) {
     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
   }
   validateEventDateWithinTrip(dto.getDate(), trip);
+}
+public boolean hasTimeConflict(Event a, Event b) {
+  if (!a.getDate().equals(b.getDate())) return false;
+  return a.getTime().isBefore(b.getEndTime()) && b.getTime().isBefore(a.getEndTime());
 }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -160,6 +160,7 @@ public class EventService {
     event.setDate(dto.getDate()); 
     event.setTime(dto.getTime());
     event.setNotes(dto.getNotes());
+    event.setEndTime(dto.getEndTime());
 
     if(event.getLocation() == null) {
       event.setLocation(new Location());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
@@ -77,6 +77,7 @@ public class EventServiceTest {
     event.setEventTitle("Visit Tokyo Tower");
     event.setDate(LocalDate.of(2026, 5, 1));
     event.setTime(LocalTime.of(10, 0));
+    event.setEndTime(LocalTime.of(12, 0));
     event.setNotes("Bring camera");
     event.setLocation(location);
     event.setCreator(member);
@@ -86,6 +87,7 @@ public class EventServiceTest {
     validPostDTO.setEventTitle("Visit Tokyo Tower");
     validPostDTO.setDate(LocalDate.of(2026, 5, 1));
     validPostDTO.setTime(LocalTime.of(10, 0));
+    validPostDTO.setEndTime(LocalTime.of(12, 0));
     validPostDTO.setPlaceId("place-001");
     validPostDTO.setPlaceName("Tokyo Tower");
     validPostDTO.setLat(35.6586);
@@ -373,5 +375,23 @@ public class EventServiceTest {
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.deleteEvent(10L, 100L, null));
     assertEquals(403, ex.getStatusCode().value());
+  }
+
+  @Test
+  public void createEvent_missingTime_throws400() {
+    validPostDTO.setTime(null);
+
+    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+            () -> eventService.createEvent(10L, validPostDTO, member));
+    assertEquals(400, ex.getStatusCode().value());
+  }
+
+  @Test
+  public void createEvent_missingEndTime_throws400() {
+    validPostDTO.setEndTime(null);
+
+    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+            () -> eventService.createEvent(10L, validPostDTO, member));
+    assertEquals(400, ex.getStatusCode().value());
   }
 }


### PR DESCRIPTION
Adds `endTime` to the `Event` entity and all related DTOs, enforces `time` and `endTime` as required fields on event creation and update, adds `hasTimeConflict` service method for detecting overlapping events.

## Changes
- **`Event.java`** — added `endTime` (`LocalTime`, non-nullable)
- **`EventPostDTO.java`** — added `endTime` field
- **`EventPutDTO.java`** — added `endTime` field  
- **`EventGetDTO.java`** — added `endTime` field, updated `equals()` and `hashCode()`
- **`DTOMapper.java`** — mapped `endTime` in `convertEntityToEventGetDTO` and `convertEventPostDTOtoEntity`; added `convertEventPutDTOtoEntity`; added missing `EventPutDTO` import
- **`EventService.java`** — enforced `time` and `endTime` as required in `validateEventPostDTO` and `validateEventPutDTO`; added public `hasTimeConflict(Event a, Event b)` method
- **`EventServiceTest.java`** — updated `@BeforeEach` setup to include `time` and `endTime`; added `createEvent_missingTime_throws400` and `createEvent_missingEndTime_throws400`
- **`ParticipationStatus.java`** — new enum (`JOINED`, `DISMISSED`, `OPTED_OUT`)
- **`EventMember.java`** — new join entity linking `User ↔ Event` with `participationStatus`
- **`EventMemberRepository.java`** — new repository with queries: find by event, find by user + event, find by user + trip, update status

Closes #181
Closes #182 
Closes #183 