### PR TITLE
Feature/12 online presence indicator

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
@@ -4,16 +4,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.context.request.WebRequest;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ItineraryPollingResponseDTO;
 
 import ch.uzh.ifi.hase.soprafs26.entity.User;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPutDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 import ch.uzh.ifi.hase.soprafs26.service.EventService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 
-import java.util.List;
 
 @RestController
 @RequestMapping("/trips")
@@ -27,20 +26,23 @@ public class EventController {
   }
 
   @GetMapping("/{tripId}/events")
-  public ResponseEntity<List<DayDTO>> getEventsGroupedByDay(
+  public ResponseEntity<ItineraryPollingResponseDTO> getEventsGroupedByDay(
       @PathVariable Long tripId,
       @RequestHeader("Authorization") String token,
       WebRequest webRequest) {
 
     User requestingUser = userService.validateToken(token);
-    List<DayDTO> days = eventService.getEventsGroupedByDay(tripId, requestingUser);
+    ItineraryPollingResponseDTO response = eventService.getEventsGroupedByDay(tripId, requestingUser);
 
-    String eTag = String.valueOf(days.hashCode());
+    String eTag = String.valueOf(
+      response.getDays().hashCode() + response.getMembers().hashCode()
+    );
+    
     if (webRequest.checkNotModified(eTag)) {
       return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
     }
 
-    return ResponseEntity.ok(days);
+    return ResponseEntity.ok(response);
   }
 
   @PostMapping("/{tripId}/events")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Membership.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Membership.java
@@ -28,6 +28,8 @@ public class Membership implements Serializable {
     @Column(nullable = false)
     private String role; // "OWNER" or "MEMBER"
     
+    @Column(nullable = true)
+    private LocalDateTime lastSeenAt;
 
     public Long getMembershipId() {
         return membershipId;
@@ -64,5 +66,10 @@ public class Membership implements Serializable {
         this.role = role;
     }   
     
-
+    public LocalDateTime getLastSeenAt() {
+        return lastSeenAt;
+    }
+    public void setLastSeenAt(LocalDateTime lastSeenAt) {
+        this.lastSeenAt = lastSeenAt;
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ItineraryPollingResponseDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ItineraryPollingResponseDTO.java
@@ -1,0 +1,30 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.util.List;
+
+public class ItineraryPollingResponseDTO {
+   
+    private List<DayDTO> days;
+    private List<TripMemberDTO> members;
+
+    public ItineraryPollingResponseDTO(List<DayDTO> days, List<TripMemberDTO> members) {
+        this.days = days;
+        this.members = members;
+    }
+
+
+    public List<DayDTO> getDays() {
+        return days;
+    }
+    public void setDays(List<DayDTO> days) {
+        this.days = days;
+    }
+
+    public List<TripMemberDTO> getMembers() {
+        return members;
+    }
+    public void setMembers(List<TripMemberDTO> members) {
+        this.members = members;
+    }
+
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TripMemberDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TripMemberDTO.java
@@ -5,6 +5,8 @@ public class TripMemberDTO {
     private String username;
     private String role;
     private String status;
+    private Boolean active;
+    private Boolean currentUser;
 
     public Long getUserId() {
         return userId;
@@ -32,6 +34,20 @@ public class TripMemberDTO {
     }
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    public Boolean getActive() {
+        return active;
+    }
+    public void setActive(Boolean active) {
+        this.active = active;
+    }
+
+    public Boolean getCurrentUser() {
+        return currentUser;
+    }
+    public void setCurrentUser(Boolean currentUser) {
+        this.currentUser = currentUser;
     }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -8,6 +8,7 @@ import org.springframework.web.server.ResponseStatusException;
 import ch.uzh.ifi.hase.soprafs26.entity.Event;
 import ch.uzh.ifi.hase.soprafs26.entity.Trip;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.entity.Membership;
 import ch.uzh.ifi.hase.soprafs26.repository.EventRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
@@ -44,21 +45,10 @@ public class EventService {
   public List<DayDTO> getEventsGroupedByDay(Long tripId, User requestingUser) {
   
     Trip trip = findTripOrThrow(tripId); //404 if not found
-    /*Trip trip = tripRepository.findById(tripId)
-      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
-        "Trip not found."));*/
-        
-    // Membership check    
-    // boolean isMember = membershipRepository
-    //   .existsByTripIdAndUserId(tripId, requestingUser.getUserId());
-    // boolean isOwner = trip.getOwner().getUserId().equals(requestingUser.getUserId());
 
-    // if (!isMember && !isOwner) {
-    //   throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-    //     "You are not a member of this trip.");
-    // }
-
-    validateTripMember(tripId, requestingUser);
+    Membership membership = validateTripMember(tripId, requestingUser);
+    membership.setLastSeenAt(LocalDateTime.now());
+    membershipRepository.save(membership);
 
     //Fetch all events for this trip, already sorted by date asc, time asc
     List<Event> events = eventRepository
@@ -90,44 +80,8 @@ public class EventService {
   public EventGetDTO createEvent(Long tripId, EventPostDTO dto, User creator) {
     
     validateEventPostDTO(dto, null);
-    /*
-    if (dto.getEventTitle() == null || dto.getEventTitle().isBlank()) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "eventTitle is required.");
-    }
-    if (dto.getDate() == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "date is required.");
-    }
-    if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_id is required.");
-    }
-    if (dto.getPlaceName() == null || dto.getPlaceName().isBlank()) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_name is required.");
-    }
-    if (dto.getLat() == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lat is required.");
-    }
-    if (dto.getLng() == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
-    }
-    */
-    /*
-    if (dto.getDate().isBefore(trip.getStartDate()) || dto.getDate().isAfter(trip.getEndDate())) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-        "Event date is outside the trip's date range.");
-    }*/
-
     Trip trip = findTripOrThrow(tripId);
-    /*Trip trip = tripRepository.findById(tripId)
-      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
-        "Trip not found."));*/
-    
     validateTripMember(tripId, creator);
-    /*oolean isMember = membershipRepository.existsByTripIdAndUserId(tripId, creator.getUserId());
-    if (!isMember) {
-      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-        "You are not a member of this trip.");
-    }*/
-
     Event event = DTOMapper.INSTANCE.convertEventPostDTOtoEntity(dto);
 
     Location location = new Location();
@@ -202,13 +156,11 @@ public void deleteEvent(Long tripId, Long eventId, User requestingUser) {
       HttpStatus.NOT_FOUND, "Event not found.")); //404
     }
 
-  private void validateTripMember(Long tripId, User user) {
-    boolean isMember = membershipRepository.existsByTripIdAndUserId(tripId, user.getUserId());
-    if (!isMember) {
-      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-        "You are not a member of this trip.");//403
-      }
-    }
+  private Membership validateTripMember(Long tripId, User user) {
+    return membershipRepository.findByTripIdAndUserId(tripId, user.getUserId())
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN,
+        "You are not a member of this trip.")); //403
+  }
 
   private void validateEventBelongsToTrip(Event event, Long tripId) {
     if (!event.getTrip().getTripId().equals(tripId)) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -15,9 +15,11 @@ import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPutDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ItineraryPollingResponseDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs26.entity.Location;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
 
 import java.time.LocalDateTime;
 import java.time.LocalDate;
@@ -42,7 +44,7 @@ public class EventService {
     this.membershipRepository = membershipRepository;
   }
 
-  public List<DayDTO> getEventsGroupedByDay(Long tripId, User requestingUser) {
+  public ItineraryPollingResponseDTO getEventsGroupedByDay(Long tripId, User requestingUser) {
   
     Trip trip = findTripOrThrow(tripId); //404 if not found
 
@@ -72,7 +74,27 @@ public class EventService {
       cursor = cursor.plusDays(1);
     }
 
-    return days;
+    LocalDateTime activeThreshold = LocalDateTime.now().minusSeconds(30);
+
+    List<TripMemberDTO> members = membershipRepository.findByTrip(trip).stream()
+      .map(m -> {
+        TripMemberDTO dto = new TripMemberDTO();
+        dto.setUserId(m.getUser().getUserId());
+        dto.setUsername(m.getUser().getUsername());
+        dto.setRole(m.getRole());
+        dto.setStatus(m.getUser().getStatus().toString());
+
+        boolean active = m.getLastSeenAt() != null && m.getLastSeenAt().isAfter(activeThreshold);
+        dto.setActive(active);
+        dto.setCurrentUser(m.getUser().getUserId().equals(requestingUser.getUserId()));
+        return dto;
+      
+      })
+      .toList();
+    
+    return new ItineraryPollingResponseDTO(days, members);
+  
+
   }
 
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -199,9 +199,9 @@ private void validateEventPostDTO(EventPostDTO dto, Trip trip) {
   if (dto.getEndTime() == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "endTime is required.");
   }
-  if (trip != null) {
-    validateEventDateWithinTrip(dto.getDate(), trip);
-  }
+  
+  validateEventDateWithinTrip(dto.getDate(), trip);
+  
 }
 
 private void validateEventPutDTO(EventPutDTO dto, Trip trip) {
@@ -225,6 +225,7 @@ private void validateEventPutDTO(EventPutDTO dto, Trip trip) {
   }
   validateEventDateWithinTrip(dto.getDate(), trip);
 }
+
 public boolean hasTimeConflict(Event a, Event b) {
   if (!a.getDate().equals(b.getDate())) return false;
   return a.getTime().isBefore(b.getEndTime()) && b.getTime().isBefore(a.getEndTime());

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -79,9 +79,9 @@ public class EventService {
 
   public EventGetDTO createEvent(Long tripId, EventPostDTO dto, User creator) {
     
-    validateEventPostDTO(dto, null);
     Trip trip = findTripOrThrow(tripId);
     validateTripMember(tripId, creator);
+    validateEventPostDTO(dto, trip);
     Event event = DTOMapper.INSTANCE.convertEventPostDTOtoEntity(dto);
 
     Location location = new Location();
@@ -128,10 +128,7 @@ public class EventService {
 }
 
 public void deleteEvent(Long tripId, Long eventId, User requestingUser) {
-  if (requestingUser == null) {
-    throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User is not authenticated.");
-  }
-  
+    
   findTripOrThrow(tripId); //404 if not found
   Event event = findEventOrThrow(eventId);//404 if not found
   validateEventBelongsToTrip(event, tripId);//404 if event not in this trip
@@ -195,9 +192,7 @@ private void validateEventPostDTO(EventPostDTO dto, Trip trip) {
   if (dto.getLng() == null) {
     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
   }
-  if (trip != null) {
-    validateEventDateWithinTrip(dto.getDate(), trip);
-  }
+  validateEventDateWithinTrip(dto.getDate(), trip);
 }
 
 private void validateEventPutDTO(EventPutDTO dto, Trip trip) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
@@ -4,6 +4,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.Event;
 import ch.uzh.ifi.hase.soprafs26.entity.Location;
 import ch.uzh.ifi.hase.soprafs26.entity.Trip;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.entity.Membership;
 import ch.uzh.ifi.hase.soprafs26.repository.EventRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
@@ -46,8 +47,10 @@ public class EventServiceTest {
   private User stranger;
   private Trip trip;
   private Event event;
+  private Membership membership;
   private EventPostDTO validPostDTO;
   private EventPutDTO validPutDTO;
+
 
   @BeforeEach
   public void setup() {
@@ -83,6 +86,12 @@ public class EventServiceTest {
     event.setCreator(member);
     event.setTrip(trip);
 
+    membership = new Membership();
+    membership.setMembershipId(1L);
+    membership.setUser(member);
+    membership.setTrip(trip);
+    membership.setRole("MEMBER");
+
     validPostDTO = new EventPostDTO();
     validPostDTO.setEventTitle("Visit Tokyo Tower");
     validPostDTO.setDate(LocalDate.of(2026, 5, 1));
@@ -97,6 +106,7 @@ public class EventServiceTest {
     validPutDTO.setEventTitle("Updated Title");
     validPutDTO.setDate(LocalDate.of(2026, 5, 2));
     validPutDTO.setTime(LocalTime.of(14, 0));
+    validPutDTO.setEndTime(LocalTime.of(16, 0));
     validPutDTO.setPlaceId("place-002");
     validPutDTO.setPlaceName("Shibuya");
     validPutDTO.setLat(35.6595);
@@ -107,7 +117,7 @@ public class EventServiceTest {
   @Test
   public void getEventsGroupedByDay_memberAccess_returnsAllDays() {
     when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
-    when(membershipRepository.existsByTripIdAndUserId(10L, 1L)).thenReturn(true);
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
     when(eventRepository.findByTrip_TripIdOrderByDateAscTimeAsc(10L))
       .thenReturn(List.of(event));
 
@@ -125,7 +135,7 @@ public class EventServiceTest {
   @Test
   public void getEventsGroupedByDay_noEvents_returnsEmptyDaysForRange() {
     when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
-    when(membershipRepository.existsByTripIdAndUserId(10L, 1L)).thenReturn(true);
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
     when(eventRepository.findByTrip_TripIdOrderByDateAscTimeAsc(10L))
             .thenReturn(List.of());
 
@@ -147,7 +157,7 @@ public class EventServiceTest {
   @Test
   public void getEventsGroupedByDay_notMember_throws403() {
     when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
-    when(membershipRepository.existsByTripIdAndUserId(10L, 99L)).thenReturn(false);
+    when(membershipRepository.findByTripIdAndUserId(10L, 99L)).thenReturn(Optional.empty());
 
     // stranger is not owner (owner is member with id=1), not in membership
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
@@ -160,7 +170,7 @@ public class EventServiceTest {
   @Test
   public void createEvent_validInput_returnsEventGetDTO() {
     when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
-    when(membershipRepository.existsByTripIdAndUserId(10L, 1L)).thenReturn(true);
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
     when(eventRepository.save(any(Event.class))).thenReturn(event);
 
     EventGetDTO result = eventService.createEvent(10L, validPostDTO, member);
@@ -181,7 +191,7 @@ public class EventServiceTest {
   @Test
   public void createEvent_notMember_throws403() {
     when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
-    when(membershipRepository.existsByTripIdAndUserId(10L, 99L)).thenReturn(false);
+    when(membershipRepository.findByTripIdAndUserId(10L, 99L)).thenReturn(Optional.empty());
 
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.createEvent(10L, validPostDTO, stranger));
@@ -192,6 +202,9 @@ public class EventServiceTest {
   public void createEvent_missingTitle_throws400() {
     validPostDTO.setEventTitle(null);
 
+    when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
+
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.createEvent(10L, validPostDTO, member));
     assertEquals(400, ex.getStatusCode().value());
@@ -201,6 +214,10 @@ public class EventServiceTest {
   public void createEvent_missingDate_throws400() {
     validPostDTO.setDate(null);
 
+    when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
+
+
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.createEvent(10L, validPostDTO, member));
     assertEquals(400, ex.getStatusCode().value());
@@ -209,6 +226,10 @@ public class EventServiceTest {
   @Test
   public void createEvent_missingPlaceId_throws400() {
     validPostDTO.setPlaceId(null);
+    
+    when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
+
 
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.createEvent(10L, validPostDTO, member));
@@ -219,6 +240,10 @@ public class EventServiceTest {
   public void createEvent_missingPlaceName_throws400() {
     validPostDTO.setPlaceName(null);
 
+    when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
+
+
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.createEvent(10L, validPostDTO, member));
     assertEquals(400, ex.getStatusCode().value());
@@ -228,6 +253,9 @@ public class EventServiceTest {
   public void createEvent_missingLat_throws400() {
     validPostDTO.setLat(null);
 
+    when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
+
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.createEvent(10L, validPostDTO, member));
     assertEquals(400, ex.getStatusCode().value());
@@ -236,7 +264,34 @@ public class EventServiceTest {
   @Test
   public void createEvent_missingLng_throws400() {
     validPostDTO.setLng(null);
+    
+    when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
 
+
+    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+            () -> eventService.createEvent(10L, validPostDTO, member));
+    assertEquals(400, ex.getStatusCode().value());
+  }
+
+  @Test
+  public void createEvent_missingTime_throws400() {
+    validPostDTO.setTime(null);
+
+    when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
+
+    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+            () -> eventService.createEvent(10L, validPostDTO, member));
+    assertEquals(400, ex.getStatusCode().value());
+  }
+
+  @Test
+  public void createEvent_missingEndTime_throws400() {
+    validPostDTO.setEndTime(null);
+
+    when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.createEvent(10L, validPostDTO, member));
     assertEquals(400, ex.getStatusCode().value());
@@ -249,7 +304,7 @@ public class EventServiceTest {
   public void updateEvent_validInput_returnsUpdatedDTO() {
     when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
     when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
-    when(membershipRepository.existsByTripIdAndUserId(10L, 1L)).thenReturn(true);
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
     when(eventRepository.save(any(Event.class))).thenReturn(event);
 
     EventGetDTO result = eventService.updateEvent(10L, 100L, validPutDTO, member);
@@ -295,7 +350,7 @@ public class EventServiceTest {
   public void updateEvent_notMember_throws403() {
     when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
     when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
-    when(membershipRepository.existsByTripIdAndUserId(10L, 99L)).thenReturn(false);
+    when(membershipRepository.findByTripIdAndUserId(10L, 99L)).thenReturn(Optional.empty());
 
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.updateEvent(10L, 100L, validPutDTO, stranger));
@@ -307,7 +362,7 @@ public class EventServiceTest {
     validPutDTO.setEventTitle(null);
     when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
     when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
-    when(membershipRepository.existsByTripIdAndUserId(10L, 1L)).thenReturn(true);
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
 
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.updateEvent(10L, 100L, validPutDTO, member));
@@ -319,7 +374,7 @@ public class EventServiceTest {
     validPutDTO.setDate(LocalDate.of(2030, 1, 1)); // far outside trip range
     when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
     when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
-    when(membershipRepository.existsByTripIdAndUserId(10L, 1L)).thenReturn(true);
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
 
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.updateEvent(10L, 100L, validPutDTO, member));
@@ -327,13 +382,12 @@ public class EventServiceTest {
   }
 
   // deleteEvent 
-  //
 
   @Test
   public void deleteEvent_validInput_deletesSuccessfully() {
     when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
     when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
-    when(membershipRepository.existsByTripIdAndUserId(10L, 1L)).thenReturn(true);
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
 
     eventService.deleteEvent(10L, 100L, member);
 
@@ -363,35 +417,11 @@ public class EventServiceTest {
   public void deleteEvent_notMember_throws403() {
     when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
     when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
-    when(membershipRepository.existsByTripIdAndUserId(10L, 99L)).thenReturn(false);
+    when(membershipRepository.findByTripIdAndUserId(10L, 99L)).thenReturn(Optional.empty());
 
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.deleteEvent(10L, 100L, stranger));
     assertEquals(403, ex.getStatusCode().value());
   }
 
-  @Test
-  public void deleteEvent_nullUser_throws403() {
-    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-            () -> eventService.deleteEvent(10L, 100L, null));
-    assertEquals(403, ex.getStatusCode().value());
-  }
-
-  @Test
-  public void createEvent_missingTime_throws400() {
-    validPostDTO.setTime(null);
-
-    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-            () -> eventService.createEvent(10L, validPostDTO, member));
-    assertEquals(400, ex.getStatusCode().value());
-  }
-
-  @Test
-  public void createEvent_missingEndTime_throws400() {
-    validPostDTO.setEndTime(null);
-
-    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-            () -> eventService.createEvent(10L, validPostDTO, member));
-    assertEquals(400, ex.getStatusCode().value());
-  }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
@@ -12,6 +12,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPutDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ItineraryPollingResponseDTO;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -121,8 +122,8 @@ public class EventServiceTest {
     when(eventRepository.findByTrip_TripIdOrderByDateAscTimeAsc(10L))
       .thenReturn(List.of(event));
 
-    List<DayDTO> days = eventService.getEventsGroupedByDay(10L, member);
-
+    ItineraryPollingResponseDTO response = eventService.getEventsGroupedByDay(10L, member);
+    List<DayDTO> days = response.getDays();
     // Trip spans 3 days (May 1–3), so we expect 3 DayDTOs
     assertEquals(3, days.size());
     // The event on May 1 should appear in the first day
@@ -139,7 +140,8 @@ public class EventServiceTest {
     when(eventRepository.findByTrip_TripIdOrderByDateAscTimeAsc(10L))
             .thenReturn(List.of());
 
-    List<DayDTO> days = eventService.getEventsGroupedByDay(10L, member);
+    ItineraryPollingResponseDTO response = eventService.getEventsGroupedByDay(10L, member);
+    List<DayDTO> days = response.getDays();
 
     assertEquals(3, days.size());
     days.forEach(day -> assertEquals(0, day.getEvents().size()));


### PR DESCRIPTION
## Implemented ##

**Trip-level** presence tracking and extend the itinerary polling to include members' active status. 
- TripMemberDTO `active` = currentUser checked the trip (`lastSeenAt`) in the last 30 seconds
- Update ETag to include the change of the member presence (304 for **both** "events" and "presence of members" are unchanged)

**Test updates**
- Updated EventServiceTest to reflect:
  - new return type (ItineraryPollingResponseDTO)
  - membership-based validation (findByTripIdAndUserId)
- Fixed validation order issues (403 vs 400)
- Removed redundant null-user test (handled in UserService)
 

Note: `user.status` = the user is global on/off-line


Close #191 #192 #12 