### PR TITLE
Add trip preview endpoint for join flow (#202)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
@@ -9,6 +9,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.TripGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripDetailDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPreviewDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripJoinResponseDTO;
 import ch.uzh.ifi.hase.soprafs26.service.TripService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
@@ -43,11 +44,18 @@ public class TripController {
 	}
 
 	@PostMapping ("/join/{joinToken}")
-	@ResponseStatus(HttpStatus.OK) // 200 OK
+	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
 	public TripJoinResponseDTO joinTrip(@PathVariable String joinToken, @RequestHeader("Authorization") String token) {
 		User currentUser = userService.validateToken(token);
 		return tripService.joinTrip(joinToken, currentUser);
+	}
+
+	@GetMapping("/join/{joinToken}/preview")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public TripPreviewDTO getTripPreview(@PathVariable String joinToken) {
+		return tripService.getTripPreview(joinToken);
 	}
 
 	@GetMapping("/{tripId}")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
@@ -35,7 +35,9 @@ public class TripController {
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED) // 201 CREATED
 	@ResponseBody
-	public TripGetDTO createTrip(@RequestBody TripPostDTO tripPostDTO, @RequestHeader("Authorization") String token) {
+	public TripGetDTO createTrip(
+		@RequestBody TripPostDTO tripPostDTO, 
+		@RequestHeader("Authorization") String token) {
 		
 		User currentUser = userService.validateToken(token);
 		Trip createdTrip = tripService.createTrip(tripPostDTO, currentUser);	
@@ -46,7 +48,9 @@ public class TripController {
 	@PostMapping ("/join/{joinToken}")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
-	public TripJoinResponseDTO joinTrip(@PathVariable String joinToken, @RequestHeader("Authorization") String token) {
+	public TripJoinResponseDTO joinTrip(
+		@PathVariable("joinToken") String joinToken, 
+		@RequestHeader("Authorization") String token) {
 		User currentUser = userService.validateToken(token);
 		return tripService.joinTrip(joinToken, currentUser);
 	}
@@ -54,14 +58,17 @@ public class TripController {
 	@GetMapping("/join/{joinToken}/preview")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
-	public TripPreviewDTO getTripPreview(@PathVariable String joinToken) {
+	public TripPreviewDTO getTripPreview(
+		@PathVariable("joinToken") String joinToken) {
 		return tripService.getTripPreview(joinToken);
 	}
 
 	@GetMapping("/{tripId}")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
-	public TripDetailDTO getTripById(@PathVariable Long tripId, @RequestHeader("Authorization") String token) {
+	public TripDetailDTO getTripById(
+		@PathVariable("tripId") Long tripId, 
+		@RequestHeader("Authorization") String token) {
 		User currentUser = userService.validateToken(token);
 		Trip trip = tripService.getAuthorizedTrip(tripId, currentUser);
 		List<TripMemberDTO> members = tripService.getTripMembers(tripId, currentUser);
@@ -73,7 +80,8 @@ public class TripController {
 	@GetMapping //show all trips of the user
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
-	public List<TripGetDTO> getAllTrips(@RequestHeader("Authorization") String token) {
+	public List<TripGetDTO> getAllTrips(
+		@RequestHeader("Authorization") String token) {
 		User currentUser = userService.validateToken(token);
 		List<TripGetDTO> tripGetDTOs = new ArrayList<>();
 		for (Trip trip : tripService.getTripsForUser(currentUser)) {
@@ -85,7 +93,9 @@ public class TripController {
 	@GetMapping("/{tripId}/members")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
-	public List<TripMemberDTO> getTripMembers(@PathVariable Long tripId, @RequestHeader("Authorization") String token) {
+	public List<TripMemberDTO> getTripMembers(
+		@PathVariable("tripId") Long tripId, 
+		@RequestHeader("Authorization") String token) {
 		User currentUser = userService.validateToken(token);
 		return tripService.getTripMembers(tripId, currentUser);
 	}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TripPreviewDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TripPreviewDTO.java
@@ -1,0 +1,48 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.time.LocalDate;
+
+public class TripPreviewDTO {
+
+    private Long tripId;
+    private String tripTitle;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String illustration;
+
+    public Long getTripId() {
+        return tripId;
+    }
+    public void setTripId(Long tripId) {
+        this.tripId = tripId;
+    }
+
+    public String getTripTitle() {
+        return tripTitle;
+    }
+    public void setTripTitle(String tripTitle) {
+        this.tripTitle = tripTitle;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public String getIllustration() {
+        return illustration;
+    }
+    public void setIllustration(String illustration) {
+        this.illustration = illustration;
+    }
+    
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -111,12 +111,10 @@ public class TripService {
             membershipRepository.save(membership);
         }
 
-        
         TripJoinResponseDTO response = new TripJoinResponseDTO();
         response.setTripId(trip.getTripId());
         response.setTripTitle(trip.getTripTitle());
         response.setAlreadyMember(alreadyMember);
-
         return response;
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -21,6 +21,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripJoinResponseDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPreviewDTO;
 
 @Service
 @Transactional
@@ -81,10 +82,24 @@ public class TripService {
         return shareCode;
     }
 
-    public TripJoinResponseDTO joinTrip(String joinToken, User currentUser){
-        Trip trip = tripRepository.findByShareCode(joinToken)
+    private Trip getTripByShareCode(String shareCode) {
+        return tripRepository.findByShareCode(shareCode)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Trip not found with the provided share code."));
+    }
 
+    public TripPreviewDTO getTripPreview(String joinToken) {
+        Trip trip = getTripByShareCode(joinToken);
+        TripPreviewDTO preview = new TripPreviewDTO();
+        preview.setTripId(trip.getTripId());
+        preview.setTripTitle(trip.getTripTitle());
+        preview.setStartDate(trip.getStartDate());
+        preview.setEndDate(trip.getEndDate());
+        preview.setIllustration(null);
+        return preview;
+    }
+
+    public TripJoinResponseDTO joinTrip(String joinToken, User currentUser){
+        Trip trip = getTripByShareCode(joinToken);
         boolean alreadyMember = membershipRepository.existsByTripAndUser(trip, currentUser);
 
         if (!alreadyMember) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
@@ -3,6 +3,7 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 import ch.uzh.ifi.hase.soprafs26.entity.Trip;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPreviewDTO;
 import ch.uzh.ifi.hase.soprafs26.service.TripService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 
@@ -20,8 +21,9 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -59,20 +61,21 @@ public class TripControllerTest {
 
     @Test
     public void joinTripInvalidTokenReturns404() throws Exception {
-        given(userService.validateToken(AUTH_TOKEN)).willReturn(mockUser());
-        given(tripService.joinTrip(eq("badtoken"), any()))
-                .willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND));
-
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        when(tripService.joinTrip(eq("badtoken"), any(User.class)))
+                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND));
+        
         mockMvc.perform(post("/trips/join/badtoken")
                         .header(AUTH_HEADER, AUTH_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
     }
 
+
     @Test
     public void createTripValidInputReturns201() throws Exception {
-        given(userService.validateToken(AUTH_TOKEN)).willReturn(mockUser());
-        given(tripService.createTrip(any(), any())).willReturn(mockTrip());
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        when(tripService.createTrip(any(), any(User.class))).thenReturn(mockTrip());
 
         String body = "{\"tripTitle\":\"Test Trip\",\"startDate\":\"2026-06-01\",\"endDate\":\"2026-06-10\"}";
 
@@ -87,9 +90,9 @@ public class TripControllerTest {
     public void getTripByIdValidIdReturns200() throws Exception {
         User user = mockUser();
         Trip trip = mockTrip();
-        given(userService.validateToken(AUTH_TOKEN)).willReturn(user);
-        given(tripService.getAuthorizedTrip(eq(1L), any())).willReturn(trip);
-        given(tripService.getTripMembers(eq(1L), any())).willReturn(Collections.emptyList());
+        when(userService.validateToken(anyString())).thenReturn(user);
+        when(tripService.getAuthorizedTrip(eq(1L), any(User.class))).thenReturn(trip);
+        when(tripService.getTripMembers(eq(1L), any(User.class))).thenReturn(Collections.emptyList());
 
         mockMvc.perform(get("/trips/1")
                         .header(AUTH_HEADER, AUTH_TOKEN)
@@ -99,9 +102,9 @@ public class TripControllerTest {
 
     @Test
     public void getTripByIdUnauthorizedReturns403() throws Exception {
-        given(userService.validateToken(AUTH_TOKEN)).willReturn(mockUser());
-        given(tripService.getAuthorizedTrip(eq(1L), any()))
-                .willThrow(new ResponseStatusException(HttpStatus.FORBIDDEN));
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        when(tripService.getAuthorizedTrip(eq(1L), any(User.class)))
+                .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN));
 
         mockMvc.perform(get("/trips/1")
                         .header(AUTH_HEADER, AUTH_TOKEN)
@@ -111,8 +114,8 @@ public class TripControllerTest {
 
     @Test
     public void getAllTripsReturns200() throws Exception {
-        given(userService.validateToken(AUTH_TOKEN)).willReturn(mockUser());
-        given(tripService.getTripsForUser(any())).willReturn(List.of(mockTrip()));
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        when(tripService.getTripsForUser(any(User.class))).thenReturn(List.of(mockTrip()));
 
         mockMvc.perform(get("/trips")
                         .header(AUTH_HEADER, AUTH_TOKEN)
@@ -127,12 +130,38 @@ public class TripControllerTest {
         member.setUsername("testuser");
         member.setRole("OWNER");
 
-        given(userService.validateToken(AUTH_TOKEN)).willReturn(mockUser());
-        given(tripService.getTripMembers(eq(1L), any())).willReturn(List.of(member));
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        when(tripService.getTripMembers(eq(1L), any(User.class))).thenReturn(List.of(member));
 
         mockMvc.perform(get("/trips/1/members")
                         .header(AUTH_HEADER, AUTH_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getTripPreviewValidShareCodeReturns200() throws Exception {
+        TripPreviewDTO preview = new TripPreviewDTO();
+        preview.setTripId(1L);
+        preview.setTripTitle("Test Trip");
+        preview.setStartDate(LocalDate.of(2026, 6, 1));
+        preview.setEndDate(LocalDate.of(2026, 6, 10));
+        preview.setIllustration(null);
+
+        when(tripService.getTripPreview("abc12345")).thenReturn(preview);
+    
+        mockMvc.perform(get("/trips/join/abc12345/preview")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getTripPreviewInvalidShareCodeReturns404() throws Exception {
+        when(tripService.getTripPreview("badcode"))
+                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        mockMvc.perform(get("/trips/join/badcode/preview")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripJoinResponseDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPreviewDTO;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -93,5 +94,20 @@ public class TripServiceIntegrationTest {
                 .filter(m -> "OWNER".equals(m.getRole()))
                 .count();
         assertEquals(1, ownerMemberships);
+    }
+
+    @Test
+    public void getTripPreviewRetursTripDataWithoutCreatingMembership() {
+        TripPreviewDTO preview = tripService.getTripPreview(SHARE_CODE);
+
+        assertNotNull(preview);
+        assertEquals(trip.getTripId(), preview.getTripId());
+        assertEquals("Integration Trip", preview.getTripTitle());
+        assertEquals(LocalDate.of(2026,7,1), preview.getStartDate());
+        assertEquals(LocalDate.of(2026,7,10), preview.getEndDate());
+        assertNull(preview.getIllustration());
+
+        List<?> memberships = membershipRepository.findByTrip(trip);
+        assertEquals(0, memberships.size());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -10,6 +10,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripJoinResponseDTO;  
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPreviewDTO;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,7 +96,7 @@ public class TripServiceTest {
         tripPostDTO.setEndDate(LocalDate.of(2026, 4, 10));
     }
 
-    @Test //getAuthorizedTrip() 200
+    @Test //getAuthorizedTrip() 200, 403, 404
     public void testGetAuthorizedTrip200() {
         when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
         when(membershipRepository.existsByTripAndUser(trip, owner)).thenReturn(true);
@@ -158,6 +159,8 @@ public class TripServiceTest {
         when(membershipRepository.findByUser(owner)).thenReturn(List.of(membership1, membership2));
         List<Trip> trips = tripService.getTripsForUser(owner);
         assertNotNull(trips);
+        assertEquals("Japan Trip", trips.get(0).getTripTitle());
+        assertEquals("Korea Trip", trips.get(1).getTripTitle());
         assertEquals(2, trips.size());
     }
 
@@ -172,6 +175,8 @@ public class TripServiceTest {
         when(membershipRepository.findByTrip(trip)).thenReturn(List.of(membership1, membership2));
         List<TripMemberDTO> members = tripService.getTripMembers(10L, owner);
         assertNotNull(members);
+        assertEquals("owner", members.get(0).getUsername());
+        assertEquals("member", members.get(1).getUsername());
         assertEquals(2, members.size());
     }
 
@@ -188,7 +193,19 @@ public class TripServiceTest {
         assertThrows(ResponseStatusException.class, () -> tripService.getTripMembers(10L, owner));
     }
 
-    @Test //joinTrip() 200
+    @Test //getTripPreview() 200
+    public void testGetTripPreview200() {
+        when(tripRepository.findByShareCode("ABC12345")).thenReturn(Optional.of(trip));
+        TripPreviewDTO preview = tripService.getTripPreview("ABC12345");
+        assertNotNull(preview);
+        assertEquals(10L, preview.getTripId());
+        assertEquals("Japan Trip", preview.getTripTitle());
+        assertEquals(LocalDate.of(2026, 4, 1), preview.getStartDate());
+        assertEquals(LocalDate.of(2026, 4, 10), preview.getEndDate());
+        assertNull(preview.getIllustration());
+    }
+
+    @Test //joinTrip() 200 (new member)
     public void testJoinTrip200() {
        when(tripRepository.findByShareCode("ABC12345")).thenReturn(Optional.of(trip));
        when(membershipRepository.existsByTripAndUser(trip, member)).thenReturn(false);
@@ -198,15 +215,19 @@ public class TripServiceTest {
        assertEquals(10L, response.getTripId());
        assertEquals("Japan Trip", response.getTripTitle());
        assertFalse(response.isAlreadyMember());
+       verify(membershipRepository, times(1)).save(any(Membership.class));
     }
 
-    @Test //joinTrip() 400 already a member
-    public void testJoinTrip400() {
+    @Test //joinTrip()  200 (already a member)
+    public void testJoinTripAlreadyMember200() {
         when(tripRepository.findByShareCode("ABC12345")).thenReturn(Optional.of(trip));
         when(membershipRepository.existsByTripAndUser(trip, member)).thenReturn(true);
 
         TripJoinResponseDTO response = tripService.joinTrip("ABC12345", member);
 
+        assertNotNull(response);
+        assertEquals(10L, response.getTripId());
+        assertEquals("Japan Trip", response.getTripTitle());
         assertTrue(response.isAlreadyMember());
         verify(membershipRepository, never()).save(any(Membership.class));
     }
@@ -217,7 +238,7 @@ public class TripServiceTest {
         assertThrows(ResponseStatusException.class, () -> tripService.joinTrip("INVALID_CODE", member));
     }
 
-    @Test //checkMembership() 403 if not a member
+    @Test //checkMembership() 403 if not a member or owner
     public void testCheckMembership403() {
         when(membershipRepository.existsByTripAndUser(trip, stranger)).thenReturn(false);
         assertThrows(ResponseStatusException.class, () -> tripService.checkMembership(trip, stranger));


### PR DESCRIPTION
## Goal

Add trip preview endpoint to support the frontend in enhancing UX. 
When users use the join link, they have a preview of the trip before joining in.

## Implemented

- Add new endpoint: `GET /trips/join/{joinToken}/preview`
  - display: tripId, tripTitle, startDate, endDate, illustration 
- Introduce `TripPreviewDTO` 
  - Illustration is set "null"
- Update relevant tests: including TripServiceTest, TripControllerTest and TripIntegrationTest 



Close #203 #204 #205 #206 #207 