### PR TITLE
Auto-enroll members on event creation and trip join (#185 #186)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventMemberRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventMemberRepository.java
@@ -11,6 +11,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.Event;
 import ch.uzh.ifi.hase.soprafs26.entity.EventMember;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 
+
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -20,6 +20,9 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs26.entity.Location;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
+import ch.uzh.ifi.hase.soprafs26.entity.EventMember;
+import ch.uzh.ifi.hase.soprafs26.constant.ParticipationStatus;
+import ch.uzh.ifi.hase.soprafs26.repository.EventMemberRepository;
 
 import java.time.LocalDateTime;
 import java.time.LocalDate;
@@ -35,13 +38,16 @@ public class EventService {
   private final EventRepository eventRepository;
   private final TripRepository tripRepository;
   private final MembershipRepository membershipRepository;
+  private final EventMemberRepository eventMemberRepository;
 
   public EventService(EventRepository eventRepository,
                       TripRepository tripRepository,
-                      MembershipRepository membershipRepository) {
+                      MembershipRepository membershipRepository,
+                      EventMemberRepository eventMemberRepository) {
     this.eventRepository = eventRepository;
     this.tripRepository = tripRepository;
     this.membershipRepository = membershipRepository;
+    this.eventMemberRepository = eventMemberRepository;
   }
 
   public ItineraryPollingResponseDTO getEventsGroupedByDay(Long tripId, User requestingUser) {
@@ -118,8 +124,8 @@ public class EventService {
     event.setCreatedAt(LocalDateTime.now());
 
     Event saved = eventRepository.save(event);
+    autoEnrollMembersForNewEvent(saved, trip);
     return DTOMapper.INSTANCE.convertEntityToEventGetDTO(saved);
-    
   }
 
 
@@ -196,61 +202,94 @@ public void deleteEvent(Long tripId, Long eventId, User requestingUser) {
       }
     }
 
-private void validateEventPostDTO(EventPostDTO dto, Trip trip) {
-  if (dto.getEventTitle() == null || dto.getEventTitle().isBlank()) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "eventTitle is required.");
+  private void validateEventPostDTO(EventPostDTO dto, Trip trip) {
+    if (dto.getEventTitle() == null || dto.getEventTitle().isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "eventTitle is required.");
+    }
+    if (dto.getDate() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "date is required.");
+    }
+    if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_id is required.");
+    }
+    if (dto.getPlaceName() == null || dto.getPlaceName().isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_name is required.");
+    }
+    if (dto.getLat() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lat is required.");
+    }
+    if (dto.getLng() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
+    }
+    if (dto.getTime() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "time is required.");
+    }
+    if (dto.getEndTime() == null) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "endTime is required.");
+    }
+    
+    validateEventDateWithinTrip(dto.getDate(), trip);
+    
   }
-  if (dto.getDate() == null) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "date is required.");
-  }
-  if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_id is required.");
-  }
-  if (dto.getPlaceName() == null || dto.getPlaceName().isBlank()) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_name is required.");
-  }
-  if (dto.getLat() == null) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lat is required.");
-  }
-  if (dto.getLng() == null) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
-  }
-  if (dto.getTime() == null) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "time is required.");
-  }
-  if (dto.getEndTime() == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "endTime is required.");
-  }
-  
-  validateEventDateWithinTrip(dto.getDate(), trip);
-  
-}
 
-private void validateEventPutDTO(EventPutDTO dto, Trip trip) {
-  if (dto.getEventTitle() == null || dto.getEventTitle().isBlank()) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "eventTitle is required.");
+  private void validateEventPutDTO(EventPutDTO dto, Trip trip) {
+    if (dto.getEventTitle() == null || dto.getEventTitle().isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "eventTitle is required.");
+    }
+    if (dto.getDate() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "date is required.");
+    }
+    if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_id is required.");
+    }
+    if (dto.getPlaceName() == null || dto.getPlaceName().isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_name is required.");
+    }
+    if (dto.getLat() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lat is required.");
+    }
+    if (dto.getLng() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
+    }
+    validateEventDateWithinTrip(dto.getDate(), trip);
   }
-  if (dto.getDate() == null) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "date is required.");
-  }
-  if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_id is required.");
-  }
-  if (dto.getPlaceName() == null || dto.getPlaceName().isBlank()) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "place_name is required.");
-  }
-  if (dto.getLat() == null) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lat is required.");
-  }
-  if (dto.getLng() == null) {
-    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
-  }
-  validateEventDateWithinTrip(dto.getDate(), trip);
-}
 
-public boolean hasTimeConflict(Event a, Event b) {
-  if (!a.getDate().equals(b.getDate())) return false;
-  return a.getTime().isBefore(b.getEndTime()) && b.getTime().isBefore(a.getEndTime());
-}
+  public boolean hasTimeConflict(Event a, Event b) {
+    if (!a.getDate().equals(b.getDate())) return false;
+    return a.getTime().isBefore(b.getEndTime()) && b.getTime().isBefore(a.getEndTime());
+  }
+
+  public void autoEnrollMembersForNewEvent(Event newEvent, Trip trip) {
+    List<Membership> memberships = membershipRepository.findByTrip(trip);
+
+    for (Membership membership : memberships) {
+      User member = membership.getUser();
+
+      List<EventMember> existingMemberships = eventMemberRepository
+        .findByUserAndTripId(member, trip.getTripId());
+
+      boolean hasConflict = existingMemberships.stream()
+        .filter(em -> em.getParticipationStatus() == ParticipationStatus.JOINED)
+        .anyMatch(em -> hasTimeConflict(newEvent, em.getEvent()));
+
+      if (!hasConflict) {
+        EventMember em = new EventMember();
+        em.setEvent(newEvent);
+        em.setUser(member);
+        em.setParticipationStatus(ParticipationStatus.JOINED);
+        eventMemberRepository.save(em);
+      }
+    }
+  }
+
+  public void autoEnrollSingleMember(Event event, User member) {
+    if (eventMemberRepository.findByEventAndUser(event, member).isPresent()) return;
+
+    EventMember em = new EventMember();
+    em.setEvent(event);
+    em.setUser(member);
+    em.setParticipationStatus(ParticipationStatus.JOINED);
+    eventMemberRepository.save(em);
+  }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -21,6 +21,8 @@ import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripJoinResponseDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
+import ch.uzh.ifi.hase.soprafs26.entity.Event;
+import ch.uzh.ifi.hase.soprafs26.repository.EventRepository;
 
 @Service
 @Transactional
@@ -29,10 +31,15 @@ public class TripService {
     private final Logger log = LoggerFactory.getLogger(TripService.class);
     private final TripRepository tripRepository;
     private final MembershipRepository membershipRepository;
+    private final EventRepository eventRepository;
+    private final EventService eventService;
 
-    public TripService(TripRepository tripRepository, MembershipRepository membershipRepository) {
+    public TripService(TripRepository tripRepository, MembershipRepository membershipRepository, EventRepository eventRepository,
+                   EventService eventService) {
         this.tripRepository = tripRepository;
         this.membershipRepository = membershipRepository;
+        this.eventRepository = eventRepository;
+        this.eventService = eventService;
     }
 
     public Trip createTrip(TripPostDTO tripPostDTO, User owner) {
@@ -94,6 +101,7 @@ public class TripService {
             membership.setRole("MEMBER");
             membership.setJoinedAt(LocalDateTime.now());
             membershipRepository.save(membership);
+            autoEnrollNewMemberForExistingEvents(currentUser, trip);
         }
 
         
@@ -153,6 +161,24 @@ public class TripService {
         Trip trip = getTripById(tripId);
         checkMembership(trip, currentUser);
         return trip;
+    }
+
+
+    private void autoEnrollNewMemberForExistingEvents(User newMember, Trip trip) {
+        List<Event> tripEvents = eventRepository
+            .findByTrip_TripIdOrderByDateAscTimeAsc(trip.getTripId());
+
+        List<Event> enrolledSoFar = new ArrayList<>();
+
+        for (Event event : tripEvents) {
+            boolean hasConflict = enrolledSoFar.stream()
+                .anyMatch(enrolled -> eventService.hasTimeConflict(event, enrolled));
+
+            if (!hasConflict) {
+                eventService.autoEnrollSingleMember(event, newMember);
+                enrolledSoFar.add(event);
+            }
+        }
     }
 
     

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -9,7 +9,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripJoinResponseDTO;  
-import ch.uzh.ifi.hase.soprafs26.rest.dto.EventRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.repository.EventRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPreviewDTO;
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -9,6 +9,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripJoinResponseDTO;  
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPreviewDTO;
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -10,6 +10,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripJoinResponseDTO;  
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
+import ch.uzh.ifi.hase.soprafs26.repository.EventRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,10 @@ public class TripServiceTest {
     private TripRepository tripRepository;
     @Mock
     private MembershipRepository membershipRepository;
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private EventService eventService;
     @InjectMocks
     private TripService tripService;
 
@@ -188,16 +193,17 @@ public class TripServiceTest {
         assertThrows(ResponseStatusException.class, () -> tripService.getTripMembers(10L, owner));
     }
 
-    @Test //joinTrip() 200
+    @Test
     public void testJoinTrip200() {
-       when(tripRepository.findByShareCode("ABC12345")).thenReturn(Optional.of(trip));
-       when(membershipRepository.existsByTripAndUser(trip, member)).thenReturn(false);
-       
-       TripJoinResponseDTO response = tripService.joinTrip("ABC12345", member);
-       assertNotNull(response);
-       assertEquals(10L, response.getTripId());
-       assertEquals("Japan Trip", response.getTripTitle());
-       assertFalse(response.isAlreadyMember());
+    when(tripRepository.findByShareCode("ABC12345")).thenReturn(Optional.of(trip));
+    when(membershipRepository.existsByTripAndUser(trip, member)).thenReturn(false);
+    when(eventRepository.findByTrip_TripIdOrderByDateAscTimeAsc(10L)).thenReturn(List.of());
+
+    TripJoinResponseDTO response = tripService.joinTrip("ABC12345", member);
+    assertNotNull(response);
+    assertEquals(10L, response.getTripId());
+    assertEquals("Japan Trip", response.getTripTitle());
+    assertFalse(response.isAlreadyMember());
     }
 
     @Test //joinTrip() 400 already a member

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -7,9 +7,9 @@ import ch.uzh.ifi.hase.soprafs26.entity.Membership;
 import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.EventRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripJoinResponseDTO;  
-import ch.uzh.ifi.hase.soprafs26.rest.dto.repository.EventRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPreviewDTO;
 


### PR DESCRIPTION
Implements automatic EventMember enrollment logic for two scenarios: when a new event is created (all current trip members with no time conflict are auto-enrolled), and when a new member joins a trip (they are auto-enrolled into all existing non-conflicting events).

## Changes
- **`EventService.java`** — injected `EventMemberRepository`; added `autoEnrollMembersForNewEvent` (called after event save in `createEvent`); added `autoEnrollSingleMember` (used by `TripService` for per-event enrollment)
- **`TripService.java`** — injected `EventRepository` and `EventService`; added `autoEnrollNewMemberForExistingEvents` (called inside `joinTrip` when user is a new member); iterates existing trip events in chronological order, skipping any that conflict with already-enrolled ones
- **`TripServiceTest.java`** — added `@Mock` for `EventRepository` and `EventService`; stubbed `findByTrip_TripIdOrderByDateAscTimeAsc` in `testJoinTrip200` to prevent NPE

Closes #185 
Closes #186