### PR TITLE
Add event join and dismiss endpoints (#187 #188)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
@@ -49,33 +49,56 @@ public class EventController {
   @ResponseStatus(HttpStatus.CREATED)
   @ResponseBody
   public EventGetDTO createEvent(
-        @PathVariable Long tripId,
-        @RequestHeader("Authorization") String token,
-        @RequestBody EventPostDTO eventPostDTO) {
-          User requestingUser = userService.validateToken(token);
-          return eventService.createEvent(tripId, eventPostDTO, requestingUser);
+      @PathVariable Long tripId,
+      @RequestHeader("Authorization") String token,
+      @RequestBody EventPostDTO eventPostDTO) {
+        User requestingUser = userService.validateToken(token);
+        return eventService.createEvent(tripId, eventPostDTO, requestingUser);
   }
 
   @PutMapping("/{tripId}/events/{eventId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ResponseBody
   public EventGetDTO updateEvent(
-        @PathVariable Long tripId,
-        @PathVariable Long eventId,
-        @RequestHeader("Authorization") String token,
-        @RequestBody EventPutDTO eventPutDTO) {
-          User requestingUser = userService.validateToken(token);
-          return eventService.updateEvent(tripId, eventId, eventPutDTO, requestingUser);
+      @PathVariable Long tripId,
+      @PathVariable Long eventId,
+      @RequestHeader("Authorization") String token,
+      @RequestBody EventPutDTO eventPutDTO) {
+        User requestingUser = userService.validateToken(token);
+        return eventService.updateEvent(tripId, eventId, eventPutDTO, requestingUser);
   }
 
   @DeleteMapping("/{tripId}/events/{eventId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)  //204
   public void deleteEvent(
+      @PathVariable Long tripId,
+      @PathVariable Long eventId,
+      @RequestHeader("Authorization") String token) {
+        User requestingUser = userService.validateToken(token);
+        eventService.deleteEvent(tripId, eventId, requestingUser);
+  }
+
+  @PostMapping("/{tripId}/events/{eventId}/join")
+  @ResponseBody
+  public ResponseEntity<EventGetDTO> joinEvent(
         @PathVariable Long tripId,
         @PathVariable Long eventId,
         @RequestHeader("Authorization") String token) {
-          User requestingUser = userService.validateToken(token);
-          eventService.deleteEvent(tripId, eventId, requestingUser);
+    User requestingUser = userService.validateToken(token);
+    EventGetDTO result = eventService.joinEvent(tripId, eventId, requestingUser);
+    return ResponseEntity.ok(result);
+  }
+
+  @DeleteMapping("/{tripId}/events/{eventId}/join")
+  @ResponseBody
+  public ResponseEntity<EventGetDTO> dismissEvent(
+        @PathVariable Long tripId,
+        @PathVariable Long eventId,
+        @RequestHeader("Authorization") String token,
+        @RequestParam(value = "conflict", defaultValue = "false") boolean fromConflictFlow) {
+    User requestingUser = userService.validateToken(token);
+    EventGetDTO result = eventService.dismissEvent(tripId, eventId, requestingUser, fromConflictFlow);
+    return ResponseEntity.ok(result);
   }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -292,4 +292,60 @@ public void deleteEvent(Long tripId, Long eventId, User requestingUser) {
     eventMemberRepository.save(em);
   }
 
+  
+  public EventGetDTO joinEvent(Long tripId, Long eventId, User requestingUser) {
+    findTripOrThrow(tripId);
+    Event event = findEventOrThrow(eventId);
+    validateEventBelongsToTrip(event, tripId);
+    validateTripMember(tripId, requestingUser);
+
+    EventMember eventMember = eventMemberRepository
+      .findByEventAndUser(event, requestingUser)
+      .orElseGet(() -> {
+          EventMember em = new EventMember();
+          em.setEvent(event);
+          em.setUser(requestingUser);
+          return em;
+      });
+    eventMember.setParticipationStatus(ParticipationStatus.JOINED);
+    eventMemberRepository.save(eventMember);
+
+    List<EventMember> existingMemberships = eventMemberRepository
+        .findByUserAndTripId(requestingUser, tripId);
+
+    for (EventMember em : existingMemberships) {
+      if (!em.getEvent().getEventId().equals(eventId)
+              && em.getParticipationStatus() == ParticipationStatus.JOINED
+              && hasTimeConflict(event, em.getEvent())) {
+        em.setParticipationStatus(ParticipationStatus.DISMISSED);
+        eventMemberRepository.save(em);
+      }
+    }
+
+    return DTOMapper.INSTANCE.convertEntityToEventGetDTO(event);
+  }
+
+  public EventGetDTO dismissEvent(Long tripId, Long eventId, User requestingUser, boolean fromConflictFlow) {
+    findTripOrThrow(tripId);
+    Event event = findEventOrThrow(eventId);
+    validateEventBelongsToTrip(event, tripId);
+    validateTripMember(tripId, requestingUser);
+
+    EventMember eventMember = eventMemberRepository
+        .findByEventAndUser(event, requestingUser)
+        .orElseGet(() -> {
+            EventMember em = new EventMember();
+            em.setEvent(event);
+            em.setUser(requestingUser);
+            return em;
+        });
+
+    eventMember.setParticipationStatus(
+        fromConflictFlow ? ParticipationStatus.DISMISSED : ParticipationStatus.OPTED_OUT
+    );
+    eventMemberRepository.save(eventMember);
+
+    return DTOMapper.INSTANCE.convertEntityToEventGetDTO(event);
+  }
+
 }


### PR DESCRIPTION
Implements the join and dismiss endpoints for event participation, allowing trip members to explicitly join or dismiss events. Joining an event automatically dismisses any conflicting JOINED events for that user.

## Changes
- **`EventService.java`** — added `joinEvent`: sets the calling user's `EventMember` status to `JOINED` and auto-dismisses any other `JOINED` events in the same time window; added `dismissEvent`: sets status to `OPTED_OUT` by default, or `DISMISSED` when called from the conflict flow (via `fromConflictFlow` flag)
- **`EventController.java`** — added `POST /trips/{tripId}/events/{eventId}/join` returning updated `EventGetDTO` with 200; added `DELETE /trips/{tripId}/events/{eventId}/join` with optional `?conflict=true` query param to distinguish opt-out from conflict dismissal, returning updated `EventGetDTO` with 200


Closes #187
Closes #188