### PR TITLE
FB-05 Add event time-range validation and error handling tests(#223)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -26,6 +26,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.EventMemberRepository;
 
 import java.time.LocalDateTime;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -201,6 +202,13 @@ public void deleteEvent(Long tripId, Long eventId, User requestingUser) {
         "Event date is outside the trip's date range.");
       }
     }
+    
+  private void validateEventTimeRange(LocalTime time, LocalTime endTime) {
+    if (endTime.isBefore(time)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+        "Event end time must be after start time.");
+      }
+  }
 
   private void validateEventPostDTO(EventPostDTO dto, Trip trip) {
     if (dto.getEventTitle() == null || dto.getEventTitle().isBlank()) {
@@ -228,6 +236,7 @@ public void deleteEvent(Long tripId, Long eventId, User requestingUser) {
         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "endTime is required.");
     }
     
+    validateEventTimeRange(dto.getTime(), dto.getEndTime());
     validateEventDateWithinTrip(dto.getDate(), trip);
     
   }
@@ -251,7 +260,16 @@ public void deleteEvent(Long tripId, Long eventId, User requestingUser) {
     if (dto.getLng() == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lng is required.");
     }
+    if (dto.getTime() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "time is required.");
+    }
+    if (dto.getEndTime() == null) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "endTime is required.");  
+    }
+    
+    validateEventTimeRange(dto.getTime(), dto.getEndTime());
     validateEventDateWithinTrip(dto.getDate(), trip);
+    
   }
 
   public boolean hasTimeConflict(Event a, Event b) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -72,10 +72,10 @@ public class TripService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
                 "Start date must be before end date."); //400 Bad Request
         }
-        /*if (startDate.isBefore(LocalDate.now())) {
+        if (startDate.isBefore(LocalDate.now())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
                 "Start date must not be in the past."); //400 Bad Request
-        }*/
+        }
     }
 
     private String generateShareCode() {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
@@ -55,8 +55,8 @@ public class TripControllerTest {
         Trip trip = new Trip();
         trip.setTripId(1L);
         trip.setTripTitle("Test Trip");
-        trip.setStartDate(LocalDate.of(2026, 6, 1));
-        trip.setEndDate(LocalDate.of(2026, 6, 10));
+        trip.setStartDate(LocalDate.of(2027, 6, 1));
+        trip.setEndDate(LocalDate.of(2027, 6, 10));
         trip.setShareCode("abc12345");
         return trip;
     }
@@ -79,7 +79,7 @@ public class TripControllerTest {
         when(userService.validateToken(anyString())).thenReturn(mockUser());
         when(tripService.createTrip(any(), any(User.class))).thenReturn(mockTrip());
 
-        String body = "{\"tripTitle\":\"Test Trip\",\"startDate\":\"2026-06-01\",\"endDate\":\"2026-06-10\"}";
+        String body = "{\"tripTitle\":\"Test Trip\",\"startDate\":\"2027-06-01\",\"endDate\":\"2027-06-10\"}";
 
         mockMvc.perform(post("/trips")
                         .header(AUTH_HEADER, AUTH_TOKEN)
@@ -169,7 +169,7 @@ public class TripControllerTest {
 
     @Test
     public void createTrip_invalidTripTitle_tooLong_returnsBadRequestWithMessage() throws Exception {
-        String body = "{\"tripTitle\":\"" + "a".repeat(256) + "\",\"startDate\":\"2026-06-01\",\"endDate\":\"2026-06-10\"}";
+        String body = "{\"tripTitle\":\"" + "a".repeat(256) + "\",\"startDate\":\"2027-06-01\",\"endDate\":\"2027-06-10\"}";
 
         mockMvc.perform(post("/trips")
                         .header(AUTH_HEADER, AUTH_TOKEN)

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
@@ -66,8 +66,8 @@ public class EventServiceTest {
     trip = new Trip();
     trip.setTripId(10L);
     trip.setTripTitle("Japan Trip");
-    trip.setStartDate(LocalDate.of(2026, 5, 1));
-    trip.setEndDate(LocalDate.of(2026, 5, 3));
+    trip.setStartDate(LocalDate.of(2027, 5, 1));
+    trip.setEndDate(LocalDate.of(2027, 5, 3));
     trip.setOwner(member);
 
     Location location = new Location();
@@ -79,7 +79,7 @@ public class EventServiceTest {
     event = new Event();
     event.setEventId(100L);
     event.setEventTitle("Visit Tokyo Tower");
-    event.setDate(LocalDate.of(2026, 5, 1));
+    event.setDate(LocalDate.of(2027, 5, 1));
     event.setTime(LocalTime.of(10, 0));
     event.setEndTime(LocalTime.of(12, 0));
     event.setNotes("Bring camera");
@@ -95,7 +95,7 @@ public class EventServiceTest {
 
     validPostDTO = new EventPostDTO();
     validPostDTO.setEventTitle("Visit Tokyo Tower");
-    validPostDTO.setDate(LocalDate.of(2026, 5, 1));
+    validPostDTO.setDate(LocalDate.of(2027, 5, 1));
     validPostDTO.setTime(LocalTime.of(10, 0));
     validPostDTO.setEndTime(LocalTime.of(12, 0));
     validPostDTO.setPlaceId("place-001");
@@ -105,7 +105,7 @@ public class EventServiceTest {
 
     validPutDTO = new EventPutDTO();
     validPutDTO.setEventTitle("Updated Title");
-    validPutDTO.setDate(LocalDate.of(2026, 5, 2));
+    validPutDTO.setDate(LocalDate.of(2027, 5, 2));
     validPutDTO.setTime(LocalTime.of(14, 0));
     validPutDTO.setEndTime(LocalTime.of(16, 0));
     validPutDTO.setPlaceId("place-002");

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
@@ -299,6 +299,20 @@ public class EventServiceTest {
     assertEquals(400, ex.getStatusCode().value());
   }
 
+@Test
+public void createEvent_endTimeBeforeStartTime_throws400() {
+    validPostDTO.setTime(LocalTime.of(12, 0));
+    validPostDTO.setEndTime(LocalTime.of(11, 0));
+
+    when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
+
+    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+            () -> eventService.createEvent(10L, validPostDTO, member));
+    assertEquals(400, ex.getStatusCode().value());
+    assertEquals("Event end time must be after start time.", ex.getReason());
+    verify(eventRepository, times(0)).save(any(Event.class));
+  }
 
   //updateEvent
 
@@ -381,6 +395,21 @@ public class EventServiceTest {
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.updateEvent(10L, 100L, validPutDTO, member));
     assertEquals(400, ex.getStatusCode().value());
+  }
+
+  @Test
+  public void updateEvent_endTimeBeforeStartTime_throws400() {
+    validPutDTO.setTime(LocalTime.of(12, 0));
+    validPutDTO.setEndTime(LocalTime.of(11, 0));
+
+    when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+    when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
+
+    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+            () -> eventService.updateEvent(10L, 100L, validPutDTO, member));
+    assertEquals(400, ex.getStatusCode().value());
+    assertEquals("Event end time must be after start time.", ex.getReason());
   }
 
   // deleteEvent 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceIntegrationTest.java
@@ -52,8 +52,8 @@ public class TripServiceIntegrationTest {
 
         trip = new Trip();
         trip.setTripTitle("Integration Trip");
-        trip.setStartDate(LocalDate.of(2026, 7, 1));
-        trip.setEndDate(LocalDate.of(2026, 7, 10));
+        trip.setStartDate(LocalDate.of(2027, 7, 1));
+        trip.setEndDate(LocalDate.of(2027, 7, 10));
         trip.setShareCode(SHARE_CODE);
         trip.setOwner(user);
         tripRepository.save(trip);
@@ -85,8 +85,8 @@ public class TripServiceIntegrationTest {
     public void createTripPersistsOwnerMembership() {
         TripPostDTO dto = new TripPostDTO();
         dto.setTripTitle("New Trip");
-        dto.setStartDate(LocalDate.of(2026, 8, 1));
-        dto.setEndDate(LocalDate.of(2026, 8, 10));
+        dto.setStartDate(LocalDate.of(2027, 8, 1));
+        dto.setEndDate(LocalDate.of(2027, 8, 10));
 
         Trip created = tripService.createTrip(dto, user);
 
@@ -103,8 +103,8 @@ public class TripServiceIntegrationTest {
         assertNotNull(preview);
         assertEquals(trip.getTripId(), preview.getTripId());
         assertEquals("Integration Trip", preview.getTripTitle());
-        assertEquals(LocalDate.of(2026,7,1), preview.getStartDate());
-        assertEquals(LocalDate.of(2026,7,10), preview.getEndDate());
+        assertEquals(LocalDate.of(2027,7,1), preview.getStartDate());
+        assertEquals(LocalDate.of(2027,7,10), preview.getEndDate());
         assertNull(preview.getIllustration());
 
         List<?> memberships = membershipRepository.findByTrip(trip);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -90,15 +90,15 @@ public class TripServiceTest {
         trip = new Trip();
         trip.setTripId(10L);
         trip.setTripTitle("Japan Trip");
-        trip.setStartDate(LocalDate.of(2026, 4, 1));
-        trip.setEndDate(LocalDate.of(2026, 4, 10));
+        trip.setStartDate(LocalDate.of(2027, 7, 1));
+        trip.setEndDate(LocalDate.of(2027, 7, 10));
         trip.setOwner(owner);
         trip.setShareCode("ABC12345");
 
         tripPostDTO = new TripPostDTO();
         tripPostDTO.setTripTitle("Japan Trip");
-        tripPostDTO.setStartDate(LocalDate.of(2026, 4, 1));
-        tripPostDTO.setEndDate(LocalDate.of(2026, 4, 10));
+        tripPostDTO.setStartDate(LocalDate.of(2027, 7, 1));
+        tripPostDTO.setEndDate(LocalDate.of(2027, 7, 10));
     }
 
     @Test //getAuthorizedTrip() 200, 403, 404
@@ -129,7 +129,7 @@ public class TripServiceTest {
 
     @Test //createTrip() 400
     public void testCreateTrip400() {
-        tripPostDTO.setEndDate(LocalDate.of(2026, 3, 30)); // End date before start date
+        tripPostDTO.setEndDate(LocalDate.of(2027, 6, 30)); // End date before start date
         assertThrows(ResponseStatusException.class, () -> tripService.createTrip(tripPostDTO, owner));
     }
 
@@ -205,8 +205,8 @@ public class TripServiceTest {
         assertNotNull(preview);
         assertEquals(10L, preview.getTripId());
         assertEquals("Japan Trip", preview.getTripTitle());
-        assertEquals(LocalDate.of(2026, 4, 1), preview.getStartDate());
-        assertEquals(LocalDate.of(2026, 4, 10), preview.getEndDate());
+        assertEquals(LocalDate.of(2027, 7, 1), preview.getStartDate());
+        assertEquals(LocalDate.of(2027, 7, 10), preview.getEndDate());
         assertNull(preview.getIllustration());
     }
 


### PR DESCRIPTION
## Implemented
- Added validation in `createEvent` and `updateEvent` method in EventService.java
- Returns 400 BAD_REQUEST when endTime is before time
- Added structured error responses through existing global exception handling
- Added service tests covering invalid time-range scenarios
- Add "Start date must not be in the past." in TripService and adjust all test case day settings to avoid failure

Close #223 