### PR TITLE
Add leave trip, delete trip, transfer ownership (#13)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
@@ -100,5 +100,42 @@ public class TripController {
 		User currentUser = userService.validateToken(token);
 		return tripService.getTripMembers(tripId, currentUser);
 	}
+
+	@DeleteMapping("/{tripId}/members/me")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public java.util.Map<String, String> leaveTrip(
+			@PathVariable("tripId") Long tripId,
+			@RequestHeader("Authorization") String token) {
+
+			User currentUser = userService.validateToken(token);
+			tripService.leaveTrip(tripId, currentUser);
+			return java.util.Map.of("message", "Successfully left the trip.");
+	}	
+
+	@DeleteMapping("/{tripId}")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public java.util.Map<String, String> deleteTrip(
+		@PathVariable("tripId") Long tripId,
+		@RequestHeader("Authorization") String token) {
+
+		User currentUser = userService.validateToken(token);
+		tripService.deleteTrip(tripId, currentUser);
+		return java.util.Map.of("message", "Trip successfully deleted.");
+	}
+
+	@PatchMapping("/{tripId}/members/{userId}/owner")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public java.util.Map<String, Long> transferOwnership(
+		@PathVariable("tripId") Long tripId,
+		@PathVariable("userId") Long userId,
+		@RequestHeader("Authorization") String token) {
+
+		User currentUser = userService.validateToken(token);
+		Long newOwnerId = tripService.transferOwnership(tripId, userId, currentUser);
+		return java.util.Map.of("new_owner_id", newOwnerId);
+	}
 }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MembershipRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MembershipRepository.java
@@ -23,4 +23,8 @@ public interface MembershipRepository extends JpaRepository<Membership, Long> {
     boolean existsByTripAndUser(Trip trip, User user);
     List<Membership> findByTrip(Trip trip);
     List<Membership> findByUser(User user);
+
+    long countByTrip(Trip trip);
+
+    Optional<Membership> findByTripAndUser(Trip trip, User user);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -192,7 +192,69 @@ public class TripService {
     }
 
     
+    public void leaveTrip(Long tripId, User currentUser) {
+        Trip trip = getTripById(tripId);
+        checkMembership(trip, currentUser);
 
+        boolean isOwner = trip.getOwner().getUserId().equals(currentUser.getUserId());
+
+        if (isOwner) {
+            long memberCount = membershipRepository.countByTrip(trip);
+            if (memberCount > 1) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Trip owner cannot leave while other members remain. Transfer ownership first.");
+            }
+            tripRepository.delete(trip);
+        } else {
+            Membership membership = membershipRepository.findByTripAndUser(trip, currentUser)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "You are not a member of this trip."));
+            membershipRepository.delete(membership);
+        }
+    }
+
+    public void deleteTrip(Long tripId, User currentUser) {
+        Trip trip = getTripById(tripId);
+
+        if (!trip.getOwner().getUserId().equals(currentUser.getUserId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                "Only the trip owner can delete this trip.");
+        }
+
+        tripRepository.delete(trip);
+    }
+
+    public Long transferOwnership(Long tripId, Long newOwnerUserId, User currentUser) {
+        Trip trip = getTripById(tripId);
+
+        if (!trip.getOwner().getUserId().equals(currentUser.getUserId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                "Only the current trip owner can transfer ownership.");
+        }
+
+        if (currentUser.getUserId().equals(newOwnerUserId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                "You are already the owner of this trip.");
+        }
+
+        Membership currentOwnerMembership = membershipRepository.findByTripAndUser(trip, currentUser)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                "Owner membership record not found."));
+        currentOwnerMembership.setRole("MEMBER");
+        membershipRepository.save(currentOwnerMembership);
+
+        Membership newOwnerMembership = membershipRepository
+            .findByTripIdAndUserId(tripId, newOwnerUserId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                "Target user is not a member of this trip."));
+        newOwnerMembership.setRole("OWNER");
+        membershipRepository.save(newOwnerMembership);
+
+        trip.setOwner(newOwnerMembership.getUser());
+        tripRepository.save(trip);
+
+        return newOwnerUserId;
+    }
 
 }
 


### PR DESCRIPTION
Members can now leave a trip, owners can delete a trip, and ownership can be transferred before leaving

---

## Changes

### `MembershipRepository.java`
- Added `countByTrip(Trip)` — used to check whether the owner is the last remaining member before allowing them to leave
- Added `findByTripAndUser(Trip, User)` — derived query replacing the pattern of `existsByTripAndUser` + separate fetch; used by both `leaveTrip` and `transferOwnership`

### `TripService.java`
- `leaveTrip(tripId, currentUser)` — removes the caller's membership; blocks the owner with 400 if other members remain; deletes the entire trip if the owner is the last member
- `deleteTrip(tripId, currentUser)` — owner-only (403); delegates full cleanup to JPA cascade (`CascadeType.ALL` on `Trip.events` and `Trip.memberships`)
- `transferOwnership(tripId, newOwnerUserId, currentUser)` — owner-only (403); swaps roles on both membership rows and updates the `trip.owner` FK; returns the new owner's user ID

### `TripController.java`
- `DELETE /trips/{tripId}/members/me` → `leaveTrip` — 200 / 400 / 403
- `DELETE /trips/{tripId}` → `deleteTrip` — 200 / 403 / 404
- `PATCH /trips/{tripId}/members/{userId}/owner` → `transferOwnership` — 200 / 403 / 404

---

## Notes
- No new DTOs — one-field responses use `Map.of(...)` directly
- Trip deletion cascades automatically through the existing JPA mappings — no manual cleanup of events or memberships required
- `PATCH` is used for ownership transfer per the M2 spec (the issue description says `PUT`)

Closes #253
Closes #254
Closes #255
Closes #256
Closes #257 
