### PR TITLE
Add comprehensive test suite for event, trip, and user layers

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -161,12 +161,13 @@ public class EventService {
 }
 
 public void deleteEvent(Long tripId, Long eventId, User requestingUser) {
-    
-  findTripOrThrow(tripId); //404 if not found
-  Event event = findEventOrThrow(eventId);//404 if not found
-  validateEventBelongsToTrip(event, tripId);//404 if event not in this trip
-  
-  validateTripMember(tripId, requestingUser);//403 if not member of this trip
+  findTripOrThrow(tripId);
+  Event event = findEventOrThrow(eventId);
+  validateEventBelongsToTrip(event, tripId);
+  validateTripMember(tripId, requestingUser);
+
+  List<EventMember> eventMembers = eventMemberRepository.findByEvent(event);
+  eventMemberRepository.deleteAll(eventMembers);
 
   eventRepository.delete(event);
   eventRepository.flush();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
@@ -24,6 +24,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -177,5 +181,110 @@ class TripControllerTest {
                         .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message", is("Trip title must be at most 255 characters.")));
+    }
+
+
+    @Test
+    void deleteTrip_ownerSuccess_returns200() throws Exception {
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        doNothing().when(tripService).deleteTrip(eq(1L), any(User.class));
+
+        mockMvc.perform(delete("/trips/1").header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Trip successfully deleted.")));
+    }
+
+    @Test
+    void deleteTrip_notOwner_returns403() throws Exception {
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the trip owner can delete this trip."))
+                .when(tripService).deleteTrip(eq(1L), any(User.class));
+
+        mockMvc.perform(delete("/trips/1").header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteTrip_notFound_returns404() throws Exception {
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
+                .when(tripService).deleteTrip(eq(1L), any(User.class));
+
+        mockMvc.perform(delete("/trips/1").header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isNotFound());
+    }
+
+
+    @Test
+    void leaveTrip_memberSuccess_returns200() throws Exception {
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        doNothing().when(tripService).leaveTrip(eq(1L), any(User.class));
+
+        mockMvc.perform(delete("/trips/1/members/me").header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Successfully left the trip.")));
+    }
+
+    @Test
+    void leaveTrip_ownerWithOtherMembers_returns400() throws Exception {
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                "Trip owner cannot leave while other members remain. Transfer ownership first."))
+                .when(tripService).leaveTrip(eq(1L), any(User.class));
+
+        mockMvc.perform(delete("/trips/1/members/me").header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void leaveTrip_notMember_returns403() throws Exception {
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "You are not a member of this trip."))
+                .when(tripService).leaveTrip(eq(1L), any(User.class));
+
+        mockMvc.perform(delete("/trips/1/members/me").header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isForbidden());
+    }
+
+
+    @Test
+    void transferOwnership_success_returns200WithNewOwnerId() throws Exception {
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        when(tripService.transferOwnership(eq(1L), eq(2L), any(User.class))).thenReturn(2L);
+
+        mockMvc.perform(patch("/trips/1/members/2/owner").header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.new_owner_id").value(2L));
+    }
+
+    @Test
+    void transferOwnership_notOwner_returns403() throws Exception {
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN,
+                "Only the current trip owner can transfer ownership."))
+                .when(tripService).transferOwnership(eq(1L), eq(2L), any(User.class));
+
+        mockMvc.perform(patch("/trips/1/members/2/owner").header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void transferOwnership_toSelf_returns400() throws Exception {
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "You are already the owner of this trip."))
+                .when(tripService).transferOwnership(eq(1L), eq(1L), any(User.class));
+
+        mockMvc.perform(patch("/trips/1/members/1/owner").header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void transferOwnership_targetNotMember_returns404() throws Exception {
+        when(userService.validateToken(anyString())).thenReturn(mockUser());
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Target user is not a member of this trip."))
+                .when(tripService).transferOwnership(eq(1L), eq(99L), any(User.class));
+
+        mockMvc.perform(patch("/trips/1/members/99/owner").header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -7,6 +7,7 @@ import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.UserAuthDTO;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -25,6 +26,8 @@ import java.util.List;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -153,6 +156,67 @@ class UserControllerTest {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                     String.format("The request body could not be created.%s", e.toString()));
         }
+    }
+
+
+    @Test
+    void login_validCredentials_returns200WithToken() throws Exception {
+        User user = new User();
+        user.setUserId(1L);
+        user.setUsername("testUsername");
+        user.setToken("session-token");
+        user.setStatus(UserStatus.ONLINE);
+
+        given(userService.login("testUsername", "password123")).willReturn(user);
+
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"testUsername\",\"password\":\"password123\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username", is("testUsername")))
+                .andExpect(jsonPath("$.token", is("session-token")));
+    }
+
+    @Test
+    void login_wrongPassword_returns401() throws Exception {
+        given(userService.login("testUsername", "wrongPassword"))
+                .willThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "The password is incorrect!"));
+
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"testUsername\",\"password\":\"wrongPassword\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void login_unknownUsername_returns401() throws Exception {
+        given(userService.login("unknown", "password123"))
+                .willThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "The username is not correct!"));
+
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"unknown\",\"password\":\"password123\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+
+    @Test
+    void logout_validToken_returns200() throws Exception {
+        doNothing().when(userService).logout("valid-token");
+
+        mockMvc.perform(post("/logout")
+                        .header("Authorization", "valid-token"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void logout_invalidToken_returns401() throws Exception {
+        doThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token!"))
+                .when(userService).logout("bad-token");
+
+        mockMvc.perform(post("/logout")
+                        .header("Authorization", "bad-token"))
+                .andExpect(status().isUnauthorized());
     }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/EventRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/EventRepositoryIntegrationTest.java
@@ -1,0 +1,109 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.Event;
+import ch.uzh.ifi.hase.soprafs26.entity.Location;
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class EventRepositoryIntegrationTest {
+
+  @Autowired
+  private TestEntityManager entityManager;
+
+  @Autowired
+  private EventRepository eventRepository;
+
+  private User user;
+  private Trip trip;
+
+  @BeforeEach
+  void setup() {
+    user = new User();
+    user.setUsername("eventrepouser");
+    user.setPassword("hash");
+    user.setStatus(UserStatus.ONLINE);
+    user.setToken(UUID.randomUUID().toString());
+    entityManager.persist(user);
+
+    trip = new Trip();
+    trip.setTripTitle("Repo Test Trip");
+    trip.setStartDate(LocalDate.of(2027, 6, 1));
+    trip.setEndDate(LocalDate.of(2027, 6, 5));
+    trip.setShareCode("EVTREPO1");
+    trip.setOwner(user);
+    entityManager.persist(trip);
+
+    entityManager.flush();
+  }
+
+  private Event buildAndPersistEvent(String title, LocalDate date, LocalTime start, LocalTime end) {
+    Location location = new Location();
+    location.setPlaceId("place-001");
+    location.setName("Test Place");
+    location.setLat(47.0);
+    location.setLng(8.0);
+
+    Event event = new Event();
+    event.setEventTitle(title);
+    event.setDate(date);
+    event.setTime(start);
+    event.setEndTime(end);
+    event.setCreatedAt(LocalDateTime.now());
+    event.setLocation(location);
+    event.setCreator(user);
+    event.setTrip(trip);
+    entityManager.persist(event);
+    return event;
+  }
+
+  @Test
+  void findByTrip_TripIdOrderByDateAscTimeAsc_returnsEventsChronologically() {
+    buildAndPersistEvent("Event C", LocalDate.of(2027, 6, 2), LocalTime.of(14, 0), LocalTime.of(15, 0));
+    buildAndPersistEvent("Event A", LocalDate.of(2027, 6, 1), LocalTime.of(10, 0), LocalTime.of(11, 0));
+    buildAndPersistEvent("Event B", LocalDate.of(2027, 6, 2), LocalTime.of(9,  0), LocalTime.of(10, 0));
+    entityManager.flush();
+
+    List<Event> events = eventRepository
+            .findByTrip_TripIdOrderByDateAscTimeAsc(trip.getTripId());
+
+    assertEquals(3, events.size());
+    assertEquals("Event A", events.get(0).getEventTitle()); // June 1, 10:00
+    assertEquals("Event B", events.get(1).getEventTitle()); // June 2, 09:00
+    assertEquals("Event C", events.get(2).getEventTitle()); // June 2, 14:00
+  }
+
+  @Test
+  void findByTrip_TripIdOrderByDateAscTimeAsc_wrongTripId_returnsEmpty() {
+    buildAndPersistEvent("Event", LocalDate.of(2027, 6, 1), LocalTime.of(10, 0), LocalTime.of(11, 0));
+    entityManager.flush();
+
+    List<Event> events = eventRepository
+            .findByTrip_TripIdOrderByDateAscTimeAsc(trip.getTripId() + 999);
+
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void findByTrip_TripIdOrderByDateAscTimeAsc_noEvents_returnsEmpty() {
+    List<Event> events = eventRepository
+            .findByTrip_TripIdOrderByDateAscTimeAsc(trip.getTripId());
+
+    assertTrue(events.isEmpty());
+  }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/EventServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/EventServiceIntegrationTest.java
@@ -1,0 +1,202 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.Event;
+import ch.uzh.ifi.hase.soprafs26.entity.Membership;
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.EventRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.DayDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPutDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ItineraryPollingResponseDTO;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class EventServiceIntegrationTest {
+
+  @Autowired private EventService eventService;
+  @Autowired private UserRepository userRepository;
+  @Autowired private TripRepository tripRepository;
+  @Autowired private MembershipRepository membershipRepository;
+  @Autowired private EventRepository eventRepository;
+
+  private User user;
+  private Trip trip;
+
+  @BeforeEach
+  void setup() {
+    user = new User();
+    user.setUsername("eventintuser");
+    user.setPassword("password");
+    user.setStatus(UserStatus.ONLINE);
+    user.setToken("event-int-token");
+    userRepository.save(user);
+
+    trip = new Trip();
+    trip.setTripTitle("Event Integration Trip");
+    trip.setStartDate(LocalDate.of(2027, 6, 1));
+    trip.setEndDate(LocalDate.of(2027, 6, 5)); // 5 days
+    trip.setShareCode("EVTINT01");
+    trip.setOwner(user);
+    tripRepository.save(trip);
+
+    Membership membership = new Membership();
+    membership.setUser(user);
+    membership.setTrip(trip);
+    membership.setRole("OWNER");
+    membership.setJoinedAt(LocalDateTime.now());
+    membershipRepository.save(membership);
+  }
+
+
+  @Test
+  void createEvent_persistsToDbAndReturnsDTO() {
+    EventPostDTO dto = validPostDTO(LocalDate.of(2027, 6, 2));
+
+    EventGetDTO result = eventService.createEvent(trip.getTripId(), dto, user);
+
+    assertNotNull(result.getEventId());
+    assertEquals("Integration Event", result.getEventTitle());
+
+    List<Event> stored = eventRepository
+            .findByTrip_TripIdOrderByDateAscTimeAsc(trip.getTripId());
+    assertEquals(1, stored.size());
+  }
+
+  @Test
+  void createEvent_dateOutsideRange_throws400AndDoesNotPersist() {
+    EventPostDTO dto = validPostDTO(LocalDate.of(2027, 7, 1)); // outside June 1–5
+
+    assertThrows(ResponseStatusException.class,
+            () -> eventService.createEvent(trip.getTripId(), dto, user));
+
+    assertTrue(eventRepository
+            .findByTrip_TripIdOrderByDateAscTimeAsc(trip.getTripId()).isEmpty());
+  }
+
+
+  @Test
+  void updateEvent_persistsTitleChange() {
+    EventGetDTO created = eventService.createEvent(trip.getTripId(), validPostDTO(LocalDate.of(2027, 6, 2)), user);
+
+    EventPutDTO updateDto = validPutDTO(LocalDate.of(2027, 6, 3), "Updated Title");
+    EventGetDTO updated = eventService.updateEvent(trip.getTripId(), created.getEventId(), updateDto, user);
+
+    assertEquals("Updated Title", updated.getEventTitle());
+
+    Event stored = eventRepository.findById(created.getEventId()).orElseThrow();
+    assertEquals("Updated Title", stored.getEventTitle());
+    assertEquals(LocalDate.of(2027, 6, 3), stored.getDate());
+  }
+
+
+  @Test
+  void deleteEvent_removesFromDb() {
+    EventGetDTO created = eventService.createEvent(trip.getTripId(), validPostDTO(LocalDate.of(2027, 6, 2)), user);
+    Long eventId = created.getEventId();
+
+    eventService.deleteEvent(trip.getTripId(), eventId, user);
+
+    assertTrue(eventRepository.findById(eventId).isEmpty());
+  }
+
+
+  @Test
+  void getEventsGroupedByDay_returnsOneDayDTOPerDayInRange() {
+    eventService.createEvent(trip.getTripId(), validPostDTO(LocalDate.of(2027, 6, 2)), user);
+
+    ItineraryPollingResponseDTO response =
+            eventService.getEventsGroupedByDay(trip.getTripId(), user);
+
+    List<DayDTO> days = response.getDays();
+    assertEquals(5, days.size()); // June 1 through June 5
+
+    // June 1 — no event
+    assertEquals(LocalDate.of(2027, 6, 1), days.get(0).getDate());
+    assertEquals(0, days.get(0).getEvents().size());
+
+    // June 2 — 1 event
+    assertEquals(LocalDate.of(2027, 6, 2), days.get(1).getDate());
+    assertEquals(1, days.get(1).getEvents().size());
+  }
+
+  @Test
+  void getEventsGroupedByDay_includesCurrentUserInMembers() {
+    ItineraryPollingResponseDTO response =
+            eventService.getEventsGroupedByDay(trip.getTripId(), user);
+
+    boolean currentUserPresent = response.getMembers().stream()
+            .anyMatch(m -> m.getUserId().equals(user.getUserId()) && Boolean.TRUE.equals(m.getCurrentUser()));
+    assertTrue(currentUserPresent);
+  }
+
+
+  @Test
+  void fullLifecycle_createUpdateDelete_consistentState() {
+    // Create
+    EventGetDTO created = eventService.createEvent(trip.getTripId(), validPostDTO(LocalDate.of(2027, 6, 2)), user);
+    assertNotNull(created.getEventId());
+
+    // Update
+    EventPutDTO updateDto = validPutDTO(LocalDate.of(2027, 6, 4), "Final Title");
+    EventGetDTO updated = eventService.updateEvent(trip.getTripId(), created.getEventId(), updateDto, user);
+    assertEquals("Final Title", updated.getEventTitle());
+
+    // Verify DB reflects update
+    ItineraryPollingResponseDTO response =
+            eventService.getEventsGroupedByDay(trip.getTripId(), user);
+    DayDTO june4 = response.getDays().get(3); // index 3 = June 4
+    assertEquals(1, june4.getEvents().size());
+    assertEquals("Final Title", june4.getEvents().get(0).getEventTitle());
+
+    // Delete
+    eventService.deleteEvent(trip.getTripId(), created.getEventId(), user);
+    assertTrue(eventRepository.findById(created.getEventId()).isEmpty());
+  }
+
+
+  private EventPostDTO validPostDTO(LocalDate date) {
+    EventPostDTO dto = new EventPostDTO();
+    dto.setEventTitle("Integration Event");
+    dto.setDate(date);
+    dto.setTime(LocalTime.of(10, 0));
+    dto.setEndTime(LocalTime.of(11, 0));
+    dto.setPlaceId("place-001");
+    dto.setPlaceName("Test Place");
+    dto.setLat(47.0);
+    dto.setLng(8.0);
+    return dto;
+  }
+
+  private EventPutDTO validPutDTO(LocalDate date, String title) {
+    EventPutDTO dto = new EventPutDTO();
+    dto.setEventTitle(title);
+    dto.setDate(date);
+    dto.setTime(LocalTime.of(10, 0));
+    dto.setEndTime(LocalTime.of(11, 0));
+    dto.setPlaceId("place-001");
+    dto.setPlaceName("Test Place");
+    dto.setLat(47.0);
+    dto.setLng(8.0);
+    return dto;
+  }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/TripRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/TripRepositoryIntegrationTest.java
@@ -1,0 +1,80 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class TripRepositoryIntegrationTest {
+
+  @Autowired
+  private TestEntityManager entityManager;
+
+  @Autowired
+  private TripRepository tripRepository;
+
+  private User persistUser(String username) {
+    User user = new User();
+    user.setUsername(username);
+    user.setPassword("hashedPassword");
+    user.setStatus(UserStatus.ONLINE);
+    user.setToken(UUID.randomUUID().toString());
+    entityManager.persist(user);
+    return user;
+  }
+
+  private Trip persistTrip(User owner, String shareCode) {
+    Trip trip = new Trip();
+    trip.setTripTitle("Test Trip");
+    trip.setStartDate(LocalDate.of(2027, 7, 1));
+    trip.setEndDate(LocalDate.of(2027, 7, 10));
+    trip.setShareCode(shareCode);
+    trip.setOwner(owner);
+    entityManager.persist(trip);
+    return trip;
+  }
+
+  @Test
+  void findByShareCode_existingCode_returnsTrip() {
+    User owner = persistUser("owner1");
+    persistTrip(owner, "CODE1234");
+    entityManager.flush();
+
+    Optional<Trip> found = tripRepository.findByShareCode("CODE1234");
+
+    assertTrue(found.isPresent());
+    assertEquals("CODE1234", found.get().getShareCode());
+    assertEquals("Test Trip", found.get().getTripTitle());
+  }
+
+  @Test
+  void findByShareCode_unknownCode_returnsEmpty() {
+    Optional<Trip> found = tripRepository.findByShareCode("NOTEXIST");
+    assertFalse(found.isPresent());
+  }
+
+  @Test
+  void existsByShareCode_existingCode_returnsTrue() {
+    User owner = persistUser("owner2");
+    persistTrip(owner, "EXIST123");
+    entityManager.flush();
+
+    assertTrue(tripRepository.existsByShareCode("EXIST123"));
+  }
+
+  @Test
+  void existsByShareCode_unknownCode_returnsFalse() {
+    assertFalse(tripRepository.existsByShareCode("MISSING1"));
+  }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceTest.java
@@ -1,5 +1,7 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
+import ch.uzh.ifi.hase.soprafs26.constant.ParticipationStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.EventMember;
 import ch.uzh.ifi.hase.soprafs26.entity.Event;
 import ch.uzh.ifi.hase.soprafs26.entity.Location;
 import ch.uzh.ifi.hase.soprafs26.entity.Trip;
@@ -393,7 +395,7 @@ void createEvent_endTimeBeforeStartTime_throws400() {
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.updateEvent(10L, 100L, validPutDTO, member));
     assertEquals(404, ex.getStatusCode().value());
-}
+  }
 
   @Test
   void updateEvent_eventNotFound_throws404() {
@@ -509,6 +511,146 @@ void createEvent_endTimeBeforeStartTime_throws400() {
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> eventService.deleteEvent(10L, 100L, stranger));
     assertEquals(403, ex.getStatusCode().value());
+  }
+
+  @Test
+  void hasTimeConflict_overlappingOnSameDay_returnsTrue() {
+      Event a = new Event();
+      a.setDate(LocalDate.of(2027, 5, 1));
+      a.setTime(LocalTime.of(10, 0));
+      a.setEndTime(LocalTime.of(12, 0));
+
+      Event b = new Event();
+      b.setDate(LocalDate.of(2027, 5, 1));
+      b.setTime(LocalTime.of(11, 0));
+      b.setEndTime(LocalTime.of(13, 0));
+
+      assertTrue(eventService.hasTimeConflict(a, b));
+  }
+
+  @Test
+  void hasTimeConflict_adjacentNonOverlapping_returnsFalse() {
+      // b starts exactly when a ends — not a conflict
+      Event a = new Event();
+      a.setDate(LocalDate.of(2027, 5, 1));
+      a.setTime(LocalTime.of(10, 0));
+      a.setEndTime(LocalTime.of(11, 0));
+
+      Event b = new Event();
+      b.setDate(LocalDate.of(2027, 5, 1));
+      b.setTime(LocalTime.of(11, 0));
+      b.setEndTime(LocalTime.of(12, 0));
+
+      assertFalse(eventService.hasTimeConflict(a, b));
+  }
+
+  @Test
+  void hasTimeConflict_differentDays_returnsFalse() {
+      Event a = new Event();
+      a.setDate(LocalDate.of(2027, 5, 1));
+      a.setTime(LocalTime.of(10, 0));
+      a.setEndTime(LocalTime.of(12, 0));
+
+      Event b = new Event();
+      b.setDate(LocalDate.of(2027, 5, 2));
+      b.setTime(LocalTime.of(10, 0));
+      b.setEndTime(LocalTime.of(12, 0));
+
+      assertFalse(eventService.hasTimeConflict(a, b));
+  }
+
+  @Test
+  void joinEvent_validInput_setsJoinedAndReturnsDTO() {
+    when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+    when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
+    when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
+    when(eventMemberRepository.findByEventAndUser(event, member)).thenReturn(Optional.empty());
+    when(eventMemberRepository.findByUserAndTripId(any(User.class), any(Long.class))).thenReturn(List.of());
+    when(eventMemberRepository.findByEvent(event)).thenReturn(List.of());
+
+    EventGetDTO result = eventService.joinEvent(10L, 100L, member);
+
+    assertNotNull(result);
+    verify(eventMemberRepository, atLeastOnce()).save(any(EventMember.class));
+  }
+
+  @Test
+  void joinEvent_tripNotFound_throws404() {
+      when(tripRepository.findById(10L)).thenReturn(Optional.empty());
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+              () -> eventService.joinEvent(10L, 100L, member));
+      assertEquals(404, ex.getStatusCode().value());
+  }
+
+  @Test
+  void joinEvent_eventNotFound_throws404() {
+      when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+      when(eventRepository.findById(100L)).thenReturn(Optional.empty());
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+              () -> eventService.joinEvent(10L, 100L, member));
+      assertEquals(404, ex.getStatusCode().value());
+  }
+
+  @Test
+  void joinEvent_notMember_throws403() {
+      when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+      when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
+      when(membershipRepository.findByTripIdAndUserId(10L, 99L)).thenReturn(Optional.empty());
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+              () -> eventService.joinEvent(10L, 100L, stranger));
+      assertEquals(403, ex.getStatusCode().value());
+  }
+
+  @Test
+  void dismissEvent_notFromConflict_setsOptedOut() {
+      EventMember em = new EventMember();
+      em.setEvent(event);
+      em.setUser(member);
+      em.setParticipationStatus(ParticipationStatus.JOINED);
+
+      when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+      when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
+      when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
+      when(eventMemberRepository.findByEventAndUser(event, member)).thenReturn(Optional.of(em));
+      when(eventMemberRepository.findByEvent(event)).thenReturn(List.of());
+      when(eventMemberRepository.findByUserAndTripId(any(User.class), any(Long.class))).thenReturn(List.of());
+
+      eventService.dismissEvent(10L, 100L, member, false);
+
+      assertEquals(ParticipationStatus.OPTED_OUT, em.getParticipationStatus());
+  }
+
+  @Test
+  void dismissEvent_fromConflictFlow_setsDismissed() {
+      EventMember em = new EventMember();
+      em.setEvent(event);
+      em.setUser(member);
+      em.setParticipationStatus(ParticipationStatus.JOINED);
+
+      when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+      when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
+      when(membershipRepository.findByTripIdAndUserId(10L, 1L)).thenReturn(Optional.of(membership));
+      when(eventMemberRepository.findByEventAndUser(event, member)).thenReturn(Optional.of(em));
+      when(eventMemberRepository.findByEvent(event)).thenReturn(List.of());
+      when(eventMemberRepository.findByUserAndTripId(any(User.class), any(Long.class))).thenReturn(List.of());
+
+      eventService.dismissEvent(10L, 100L, member, true);
+
+      assertEquals(ParticipationStatus.DISMISSED, em.getParticipationStatus());
+  }
+
+  @Test
+  void dismissEvent_notMember_throws403() {
+      when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+      when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
+      when(membershipRepository.findByTripIdAndUserId(10L, 99L)).thenReturn(Optional.empty());
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+              () -> eventService.dismissEvent(10L, 100L, stranger, false));
+      assertEquals(403, ex.getStatusCode().value());
   }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -248,6 +248,146 @@ class TripServiceTest {
         assertThrows(ResponseStatusException.class, () -> tripService.checkMembership(trip, stranger));
     }
 
+
+    @Test
+    void deleteTrip_ownerSuccess_deletesTrip() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+
+        tripService.deleteTrip(10L, owner);
+
+        verify(tripRepository, times(1)).delete(trip);
+    }
+
+    @Test
+    void deleteTrip_notOwner_throws403() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> tripService.deleteTrip(10L, stranger));
+        assertEquals(403, ex.getStatusCode().value());
+        verify(tripRepository, never()).delete(any());
+    }
+
+    @Test
+    void deleteTrip_tripNotFound_throws404() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> tripService.deleteTrip(10L, owner));
+        assertEquals(404, ex.getStatusCode().value());
+    }
+
+
+    @Test
+    void leaveTrip_regularMember_removesMembership() {
+        Membership memberMembership = new Membership();
+        memberMembership.setUser(member);
+        memberMembership.setTrip(trip);
+        memberMembership.setRole("MEMBER");
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+        when(membershipRepository.existsByTripAndUser(trip, member)).thenReturn(true);
+        when(membershipRepository.findByTripAndUser(trip, member)).thenReturn(Optional.of(memberMembership));
+
+        tripService.leaveTrip(10L, member);
+
+        verify(membershipRepository, times(1)).delete(memberMembership);
+        verify(tripRepository, never()).delete(any());
+    }
+
+    @Test
+    void leaveTrip_ownerAlone_deletesTrip() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+        when(membershipRepository.existsByTripAndUser(trip, owner)).thenReturn(true);
+        when(membershipRepository.countByTrip(trip)).thenReturn(1L);
+
+        tripService.leaveTrip(10L, owner);
+
+        verify(tripRepository, times(1)).delete(trip);
+        verify(membershipRepository, never()).delete(any(Membership.class));
+    }
+
+    @Test
+    void leaveTrip_ownerWithOtherMembers_throws400() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+        when(membershipRepository.existsByTripAndUser(trip, owner)).thenReturn(true);
+        when(membershipRepository.countByTrip(trip)).thenReturn(2L);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> tripService.leaveTrip(10L, owner));
+        assertEquals(400, ex.getStatusCode().value());
+        verify(tripRepository, never()).delete(any());
+    }
+
+    @Test
+    void leaveTrip_notMember_throws403() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+        when(membershipRepository.existsByTripAndUser(trip, stranger)).thenReturn(false);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> tripService.leaveTrip(10L, stranger));
+        assertEquals(403, ex.getStatusCode().value());
+    }
+
+
+    @Test
+    void transferOwnership_success_rolesSwappedAndOwnerUpdated() {
+        Membership ownerMembership = new Membership();
+        ownerMembership.setUser(owner);
+        ownerMembership.setTrip(trip);
+        ownerMembership.setRole("OWNER");
+
+        Membership memberMembership = new Membership();
+        memberMembership.setUser(member);
+        memberMembership.setTrip(trip);
+        memberMembership.setRole("MEMBER");
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+        when(membershipRepository.findByTripAndUser(trip, owner)).thenReturn(Optional.of(ownerMembership));
+        when(membershipRepository.findByTripIdAndUserId(10L, 2L)).thenReturn(Optional.of(memberMembership));
+
+        Long result = tripService.transferOwnership(10L, 2L, owner);
+
+        assertEquals(2L, result);
+        assertEquals("MEMBER", ownerMembership.getRole());
+        assertEquals("OWNER", memberMembership.getRole());
+        assertEquals(member, trip.getOwner());
+        verify(tripRepository, times(1)).save(trip);
+    }
+
+    @Test
+    void transferOwnership_notOwner_throws403() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> tripService.transferOwnership(10L, 2L, stranger));
+        assertEquals(403, ex.getStatusCode().value());
+    }
+
+    @Test
+    void transferOwnership_toSelf_throws400() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> tripService.transferOwnership(10L, 1L, owner)); // owner.getUserId() == 1L
+        assertEquals(400, ex.getStatusCode().value());
+    }
+
+    @Test
+    void transferOwnership_targetNotMember_throws404() {
+        Membership ownerMembership = new Membership();
+        ownerMembership.setUser(owner);
+        ownerMembership.setRole("OWNER");
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
+        when(membershipRepository.findByTripAndUser(trip, owner)).thenReturn(Optional.of(ownerMembership));
+        when(membershipRepository.findByTripIdAndUserId(10L, 99L)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> tripService.transferOwnership(10L, 99L, owner));
+        assertEquals(404, ex.getStatusCode().value());
+    }
+
 }
 
 


### PR DESCRIPTION
## Tests added

**Controller layer**
- `TripControllerTest` — `deleteTrip` (200/403/404), `leaveTrip` (200/400/403), `transferOwnership` (200/403/400/404)
- `UserControllerTest` — `POST /login` (200/401/401), `POST /logout` (200/401)

**Service layer**
- `TripServiceTest` — `deleteTrip`, `leaveTrip`, `transferOwnership` including all error paths
- `EventServiceTest` — `joinEvent`, `dismissEvent`, `hasTimeConflict`

**Repository integration**
- `TripRepositoryIntegrationTest` — `findByShareCode`, `existsByShareCode`
- `MembershipRepositoryIntegrationTest` — all query methods
- `EventRepositoryIntegrationTest` — chronological ordering query

**Full-stack integration**
- `EventServiceIntegrationTest` — create/update/delete lifecycle, range validation, polling response shape

## Bug fixed
`EventService.deleteEvent` now removes `EventMember` records before deleting the parent `Event`, preventing a FK constraint violation at flush time.

---