### PR TITLE
Fix additional issues SonarQube raised

### DIFF
--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/EventControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/EventControllerTest.java
@@ -247,7 +247,7 @@ class EventControllerTest {
     @Test
     void getEvents_validMember_Success200() throws Exception {
         User user = mockValidToken();
-        Mockito.when(eventService.getEventsGroupedByDay(eq(TRIP_ID), eq(user)))
+        Mockito.when(eventService.getEventsGroupedByDay(TRIP_ID, user))
             .thenReturn(mockItineraryPollingResponseDTO());
 
         performGetEvents()

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -7,7 +7,6 @@ import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.UserAuthDTO;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/EventServiceIntegrationTest.java
@@ -85,12 +85,14 @@ class EventServiceIntegrationTest {
   @Test
   void createEvent_dateOutsideRange_throws400AndDoesNotPersist() {
     EventPostDTO dto = validPostDTO(LocalDate.of(2027, 7, 1)); // outside June 1–5
+    Long tripId = trip.getTripId();
 
     assertThrows(ResponseStatusException.class,
-            () -> eventService.createEvent(trip.getTripId(), dto, user));
+            () -> eventService.createEvent(tripId, dto, user));
 
     assertTrue(eventRepository
-            .findByTrip_TripIdOrderByDateAscTimeAsc(trip.getTripId()).isEmpty());
+            .findByTrip_TripIdOrderByDateAscTimeAsc(tripId)
+            .isEmpty());
   }
 
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -70,7 +70,7 @@ class TripServiceTest {
     private TripPostDTO tripPostDTO;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         owner = new User();
         owner.setUserId(1L);
         owner.setUsername("owner");


### PR DESCRIPTION
## Implemented

- Moved `EventServiceIntegrationTest` to the correct package to align file structure with package declarations
- Refactored `assertThrows` lambdas to contain only a single potentially exception-throwing invocation for clearer test intent for `EventServiceIntegrationTest`
- Removed remaining unnecessary `public` modifiers in test classes and methods `EventControllerTest`
- Removed redundant `eq()` usages in Mockito verifications and stubbings `TripServiceTest`

Close #280 