### PR TITLE
Fix: Delete the trip when there's content left

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import ch.uzh.ifi.hase.soprafs26.entity.Event;
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
 import java.util.List;
 
 @Repository("eventRepository")
@@ -11,4 +12,5 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     List<Event> findByTrip_TripIdOrderByDateAscTimeAsc(Long tripId);
 
+    void deleteAllByTrip(Trip trip);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MembershipRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/MembershipRepository.java
@@ -27,4 +27,6 @@ public interface MembershipRepository extends JpaRepository<Membership, Long> {
     long countByTrip(Trip trip);
 
     Optional<Membership> findByTripAndUser(Trip trip, User user);
+
+    void deleteAllByTrip(Trip trip);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -32,13 +32,16 @@ public class TripService {
     private final EventRepository eventRepository;
     private final EventService eventService;
 
-    public TripService(TripRepository tripRepository, MembershipRepository membershipRepository, EventRepository eventRepository,
-                   EventService eventService) {
-        this.tripRepository = tripRepository;
-        this.membershipRepository = membershipRepository;
-        this.eventRepository = eventRepository;
-        this.eventService = eventService;
-    }
+    public TripService(
+        TripRepository tripRepository, 
+        MembershipRepository membershipRepository, 
+        EventRepository eventRepository,
+        EventService eventService) {
+            this.tripRepository = tripRepository;
+            this.membershipRepository = membershipRepository;
+            this.eventRepository = eventRepository;
+            this.eventService = eventService;
+        }
 
     public Trip createTrip(TripPostDTO tripPostDTO, User owner) {
         Trip newTrip = new Trip();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -212,7 +212,7 @@ public class TripService {
             membershipRepository.delete(membership);
         }
     }
-
+    @Transactional
     public void deleteTrip(Long tripId, User currentUser) {
         Trip trip = getTripById(tripId);
 
@@ -221,6 +221,8 @@ public class TripService {
                 "Only the trip owner can delete this trip.");
         }
 
+        eventRepository.deleteAllByTrip(trip);
+        membershipRepository.deleteAllByTrip(trip);
         tripRepository.delete(trip);
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -62,7 +62,6 @@ class TripServiceTest {
     private EventService eventService;
     @InjectMocks
     private TripService tripService;
-    private InOrder inOrder;
 
     private User owner;
     private User member;
@@ -256,6 +255,7 @@ class TripServiceTest {
 
         tripService.deleteTrip(10L, owner);
 
+        InOrder inOrder = inOrder(eventRepository, membershipRepository, tripRepository);
         inOrder.verify(eventRepository).deleteAllByTrip(trip);
         inOrder.verify(membershipRepository).deleteAllByTrip(trip);
         inOrder.verify(tripRepository).delete(trip);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.InOrder;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -62,6 +63,7 @@ class TripServiceTest {
     private EventService eventService;
     @InjectMocks
     private TripService tripService;
+    private InOrder inOrder;
 
     private User owner;
     private User member;
@@ -250,12 +252,14 @@ class TripServiceTest {
 
 
     @Test
-    void deleteTrip_ownerSuccess_deletesTrip() {
+    void deleteTrip_ownerSuccess_deletesEventsMembershipsAndTrip() {
         when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
 
         tripService.deleteTrip(10L, owner);
 
-        verify(tripRepository, times(1)).delete(trip);
+        inOrder.verify(eventRepository).deleteAllByTrip(trip);
+        inOrder.verify(membershipRepository).deleteAllByTrip(trip);
+        inOrder.verify(tripRepository).delete(trip);
     }
 
     @Test


### PR DESCRIPTION
Clear events and memberships before the trip is deleted

## Implemented

Main
- Added `deleteAllByTrip(Trip trip)` to EventRepository
- Added `deleteAllByTrip(Trip trip)` to MembershipRepository
- Updated `TripService.deleteTrip()` to: delete related events first--> delete memberships second --> delete the trip last

Test
- Updated `TripServiceTest` with ordered verification using InOrder


Close #282 