### PR TITLE
Fix: also do with eventMember

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventMemberRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/EventMemberRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import ch.uzh.ifi.hase.soprafs26.constant.ParticipationStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Event;
 import ch.uzh.ifi.hase.soprafs26.entity.EventMember;
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 
 
@@ -30,4 +31,6 @@ public interface EventMemberRepository extends JpaRepository<EventMember, Long> 
   void updateStatusByEventAndUser(@Param("event") Event event,
                                   @Param("user") User user,
                                   @Param("status") ParticipationStatus status);
+
+  void deleteAllByEvent_Trip(Trip trip);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -20,6 +20,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripJoinResponseDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripMemberDTO;
 import ch.uzh.ifi.hase.soprafs26.entity.Event;
+import ch.uzh.ifi.hase.soprafs26.repository.EventMemberRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.EventRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPreviewDTO;
 
@@ -31,16 +32,19 @@ public class TripService {
     private final MembershipRepository membershipRepository;
     private final EventRepository eventRepository;
     private final EventService eventService;
+    private final EventMemberRepository eventMemberRepository;
 
     public TripService(
         TripRepository tripRepository, 
         MembershipRepository membershipRepository, 
         EventRepository eventRepository,
-        EventService eventService) {
+        EventService eventService,
+        EventMemberRepository eventMemberRepository) {
             this.tripRepository = tripRepository;
             this.membershipRepository = membershipRepository;
             this.eventRepository = eventRepository;
             this.eventService = eventService;
+            this.eventMemberRepository = eventMemberRepository;
         }
 
     public Trip createTrip(TripPostDTO tripPostDTO, User owner) {
@@ -225,6 +229,7 @@ public class TripService {
                 "Only the trip owner can delete this trip.");
         }
 
+        eventMemberRepository.deleteAllByEvent_Trip(trip);
         eventRepository.deleteAllByTrip(trip);
         membershipRepository.deleteAllByTrip(trip);
         tripRepository.delete(trip);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -6,6 +6,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.Membership;
 import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.MembershipRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.EventMemberRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.EventRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TripJoinResponseDTO;  
@@ -58,6 +59,8 @@ class TripServiceTest {
     private MembershipRepository membershipRepository;
     @Mock
     private EventRepository eventRepository;
+    @Mock
+    private EventMemberRepository eventMemberRepository;
     @Mock
     private EventService eventService;
     @InjectMocks
@@ -250,12 +253,13 @@ class TripServiceTest {
 
 
     @Test
-    void deleteTrip_ownerSuccess_deletesEventsMembershipsAndTrip() {
+    void deleteTrip_ownerSuccess_deletesEventMembersEventsMembershipsAndTrip() {
         when(tripRepository.findById(10L)).thenReturn(Optional.of(trip));
 
         tripService.deleteTrip(10L, owner);
 
-        InOrder inOrder = inOrder(eventRepository, membershipRepository, tripRepository);
+        InOrder inOrder = inOrder(eventMemberRepository, eventRepository, membershipRepository, tripRepository);
+        inOrder.verify(eventMemberRepository).deleteAllByEvent_Trip(trip);
         inOrder.verify(eventRepository).deleteAllByTrip(trip);
         inOrder.verify(membershipRepository).deleteAllByTrip(trip);
         inOrder.verify(tripRepository).delete(trip);


### PR DESCRIPTION
Clear EventMember before the trip is deleted

## Implemented
**Main**
- Add `deleteAllByEvent_Trip(Trip trip)` to EventMemberRepository
- Updated `TripService.deleteTrip()` to: delete related eventMember--> delete related events --> delete memberships --> delete the trip last


**Test**
Updated TripServiceTest with ordered verification using InOrder

#282 